### PR TITLE
Refatoração dos testes

### DIFF
--- a/Python/crossfire/README.md
+++ b/Python/crossfire/README.md
@@ -91,3 +91,9 @@ poetry install --with dev
 poetry run black . --check
 poeytry run ruff .
 ```
+
+### Running tests
+
+```commandline
+poetry run pytest
+```

--- a/Python/crossfire/crossfire/get_fogocruzado.py
+++ b/Python/crossfire/crossfire/get_fogocruzado.py
@@ -7,7 +7,7 @@ from geopandas import GeoDataFrame, points_from_xy
 from pandas import to_numeric
 
 
-class InvalidDateInterval(Exception):
+class InvalidDateIntervalError(Exception):
     def __init__(self, start_date, end_date):
         delta = end_date - start_date
         message = (
@@ -48,7 +48,7 @@ def get_fogocruzado(
     ... )
     """
     if (final_date - initial_date).days >= 210:
-        raise InvalidDateInterval(initial_date, final_date)
+        raise InvalidDateIntervalError(initial_date, final_date)
 
     banco = extract_data_api(
         link=(

--- a/Python/crossfire/poetry.lock
+++ b/Python/crossfire/poetry.lock
@@ -234,6 +234,20 @@ pytz = "*"
 "zope.interface" = "*"
 
 [[package]]
+name = "exceptiongroup"
+version = "1.1.3"
+description = "Backport of PEP 654 (exception groups)"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "exceptiongroup-1.1.3-py3-none-any.whl", hash = "sha256:343280667a4585d195ca1cf9cef84a4e178c4b6cf2274caef9859782b567d5e3"},
+    {file = "exceptiongroup-1.1.3.tar.gz", hash = "sha256:097acd85d473d75af5bb98e41b61ff7fe35efe6675e4f9370ec6ec5126d160e9"},
+]
+
+[package.extras]
+test = ["pytest (>=6)"]
+
+[[package]]
 name = "fiona"
 version = "1.9.4.post1"
 description = "Fiona reads and writes spatial data files"
@@ -323,6 +337,17 @@ zipp = ">=0.5"
 docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
 perf = ["ipython"]
 testing = ["flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy (>=0.9.1)", "pytest-perf (>=0.9.2)", "pytest-ruff"]
+
+[[package]]
+name = "iniconfig"
+version = "2.0.0"
+description = "brain-dead simple config-ini parsing"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
+    {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
+]
 
 [[package]]
 name = "mypy-extensions"
@@ -455,6 +480,21 @@ docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.1)", "sphinx-
 test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.4)", "pytest-cov (>=4.1)", "pytest-mock (>=3.11.1)"]
 
 [[package]]
+name = "pluggy"
+version = "1.3.0"
+description = "plugin and hook calling mechanisms for python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pluggy-1.3.0-py3-none-any.whl", hash = "sha256:d89c696a773f8bd377d18e5ecda92b7a3793cbe66c87060a6fb58c7b6e1061f7"},
+    {file = "pluggy-1.3.0.tar.gz", hash = "sha256:cf61ae8f126ac6f7c451172cf30e3e43d3ca77615509771b3a984a0730651e12"},
+]
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
 name = "pyproj"
 version = "3.6.0"
 description = "Python interface to PROJ (cartographic projections and coordinate transformations library)"
@@ -490,6 +530,28 @@ files = [
 
 [package.dependencies]
 certifi = "*"
+
+[[package]]
+name = "pytest"
+version = "7.4.2"
+description = "pytest: simple powerful testing with Python"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pytest-7.4.2-py3-none-any.whl", hash = "sha256:1d881c6124e08ff0a1bb75ba3ec0bfd8b5354a01c194ddd5a0a870a48d99b002"},
+    {file = "pytest-7.4.2.tar.gz", hash = "sha256:a766259cfab564a2ad52cb1aae1b881a75c3eb7e34ca3779697c23ed47c47069"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
+iniconfig = "*"
+packaging = "*"
+pluggy = ">=0.12,<2.0"
+tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
+
+[package.extras]
+testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "python-dateutil"
@@ -759,4 +821,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "73b20db41a79658690003fa09724e0add96e023041c0b89c499dd3fa220268d6"
+content-hash = "60ffa1a1d2aa458ca4e7dcfe21869d32dcc08f4f7ee6d6138a3d3216d32749ea"

--- a/Python/crossfire/pyproject.toml
+++ b/Python/crossfire/pyproject.toml
@@ -31,6 +31,7 @@ python-decouple = "^3.5"
 [tool.poetry.group.dev.dependencies]
 black = "^23.7.0"
 ruff = "^0.0.287"
+pytest = "^7.4.2"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/Python/crossfire/tests/test_crossfire.py
+++ b/Python/crossfire/tests/test_crossfire.py
@@ -1,6 +1,7 @@
 import os
 from datetime import date
 from unittest import TestCase
+from unittest.mock import patch
 
 import numpy
 from crossfire.fogocruzado_signin import fogocruzado_signin
@@ -10,26 +11,41 @@ from crossfire.fogocruzado_utils import (
     extract_cities_api,
 )
 from crossfire.get_cities import get_cities
-from crossfire.get_fogocruzado import get_fogocruzado
-from decouple import config
+from crossfire.get_fogocruzado import InvalidDateIntervalError, get_fogocruzado
 from geopandas import GeoDataFrame
 from pandas import DataFrame
 
 
-class TestSuccessSignin(TestCase):
-    def setUp(self):
-        fogocruzado_signin(
-            config("FOGO_CRUZADO_EMAIL"), config("FOGO_CRUZADO_PASSWORD")
-        )
+def fake_api_row(**extra_fields):
+    row = {
+        "latitude_ocorrencia": 42.0,
+        "longitude_ocorrencia": 4.2,
+        "densidade_demo_cidade": 42,
+        "uf_estado": "RJ",
+        "nome_cidade": "Rio de Janeiro",
+        "presen_agen_segur_ocorrencia": 1,
+    }
+    if extra_fields:
+        row.update(extra_fields)
+    return row
 
+
+def fake_api_data(*rows):
+    return DataFrame(rows or [fake_api_row()])
+
+
+class TestSuccessSignin(TestCase):
     def test_fogocruzado_signin_environment_variable(self):
         """
         assert the parameters passed to fogocruzado_signin enables FOGO_CRUZADO varibale
         in the environment
         """
+        with patch("crossfire.fogocruzado_signin.get_token_fogocruzado") as mock:
+            fogocruzado_signin("FOGO_CRUZADO_EMAIL", "FOGO_CRUZADO_PASSWORD")
+            mock.assert_called_once_with()
+
         self.assertTrue(os.environ["FOGO_CRUZADO_EMAIL"])
         self.assertTrue(os.environ["FOGO_CRUZADO_PASSWORD"])
-        self.assertTrue(os.environ["FOGO_CRUZADO_API_TOKEN"])
 
 
 class TestFogoCruzadoKey(TestCase):
@@ -38,113 +54,122 @@ class TestFogoCruzadoKey(TestCase):
     """
 
     def setUp(self):
-        fogocruzado_signin(
-            config("FOGO_CRUZADO_EMAIL"), config("FOGO_CRUZADO_PASSWORD")
-        )
-        self.key = fogocruzado_key()
+        os.environ["FOGO_CRUZADO_API_TOKEN"] = "42"
 
     def test_environmental_variable_is_not_none(self):
-        self.assertIsNotNone(self.key)
+        self.assertIsNotNone(fogocruzado_key())
 
 
 class TestExtractDataAPI(TestCase):
-    def setUp(self):
-        fogocruzado_signin(
-            config("FOGO_CRUZADO_EMAIL"), config("FOGO_CRUZADO_PASSWORD")
-        )
-
     def test_extract_data_api(self):
-        self.data = extract_data_api(
-            link="https://api.fogocruzado.org.br/api/v1/occurrences?data_ocorrencia[gt]=2020-01-01&data_ocorrencia[lt]=2020-02-01"
-        )
-        self.assertIsInstance(self.data, DataFrame)
-        self.assertTrue(self.data is not None)
+        with patch("crossfire.fogocruzado_utils.requests.get") as mock:
+            mock.return_value.content = b"[]"
+            data = extract_data_api(
+                link="https://api.fogocruzado.org.br/api/v1/occurrences?data_ocorrencia[gt]=2020-01-01&data_ocorrencia[lt]=2020-02-01"
+            )
+        self.assertIsInstance(data, DataFrame)
 
 
 class TestExtractCitiesAPI(TestCase):
-    def setUp(self):
-        fogocruzado_signin(
-            config("FOGO_CRUZADO_EMAIL"), config("FOGO_CRUZADO_PASSWORD")
-        )
-
     def test_extract_cities_api(self):
-        self.data = extract_cities_api()
-        self.assertIsInstance(self.data, DataFrame)
-        self.assertTrue(self.data is not None)
+        with patch("crossfire.fogocruzado_utils.requests.get") as mock:
+            mock.return_value.content = b"[]"
+            data = extract_cities_api()
+        self.assertIsInstance(data, DataFrame)
 
 
 class TestGetCitiesAPI(TestCase):
-    def setUp(self):
-        fogocruzado_signin(
-            config("FOGO_CRUZADO_EMAIL"), config("FOGO_CRUZADO_PASSWORD")
-        )
-        self.cities = get_cities()
-
     def test_extract_cities_api(self):
-        self.assertIsInstance(self.cities, DataFrame)
-        self.assertTrue(self.cities is not None)
-        self.assertIsInstance(
-            type(self.cities.DensidadeDemografica[0]), type(numpy.float64)
-        )
+        with patch("crossfire.fogocruzado_utils.requests.get") as mock:
+            mock.return_value.content = b'[{"DensidadeDemografica": 42.0}]'
+            cities = get_cities()
+
+        self.assertIsInstance(cities, DataFrame)
+        self.assertIsInstance(cities.DensidadeDemografica[0], numpy.float64)
 
 
 class TestGetFogoCruzado(TestCase):
-    def setUp(self):
-        fogocruzado_signin(
-            config("FOGO_CRUZADO_EMAIL"), config("FOGO_CRUZADO_PASSWORD")
-        )
-
     def test_sucessful_get_fogocruzado(self):
-        self.sucessful_get_fogocruzado = get_fogocruzado()
-        self.assertIsInstance(self.sucessful_get_fogocruzado, GeoDataFrame)
+        with patch("crossfire.get_fogocruzado.extract_data_api") as mock:
+            mock.return_value = fake_api_data()
+            sucessful_get_fogocruzado = get_fogocruzado()
+        self.assertIsInstance(sucessful_get_fogocruzado, GeoDataFrame)
 
     def test_unsucessful_get_fogocruzado(self):
-        self.sucessful_get_fogocruzado = get_fogocruzado(
-            initial_date=date(2020, 1, 1), final_date=date(2021, 10, 1)
-        )
-        self.assertFalse(self.sucessful_get_fogocruzado)
+        with self.assertRaises(InvalidDateIntervalError):
+            self.sucessful_get_fogocruzado = get_fogocruzado(
+                initial_date=date(2020, 1, 1), final_date=date(2021, 10, 1)
+            )
 
 
 class TestFilterCityFogoCruzado(TestCase):
-    def setUp(self):
-        fogocruzado_signin(
-            config("FOGO_CRUZADO_EMAIL"), config("FOGO_CRUZADO_PASSWORD")
-        )
-
     def test_sucessful_filter_city_from_string(self):
-        self.sucessful_get_fogocruzado = get_fogocruzado(city="Rio de Janeiro")
-        self.assertTrue(
-            self.sucessful_get_fogocruzado.nome_cidade.unique()[0] == "Rio de Janeiro"
-        )
+        with patch("crossfire.get_fogocruzado.extract_data_api") as mock:
+            mock.return_value = fake_api_data(
+                fake_api_row(nome_cidade="Rio de Janeiro"),
+                fake_api_row(nome_cidade="Niterói"),
+            )
+            sucessful_get_fogocruzado = get_fogocruzado(city="Rio de Janeiro")
+            self.assertEqual(
+                sucessful_get_fogocruzado.nome_cidade.unique(), ["Rio de Janeiro"]
+            )
 
     def test_sucessful_filter_city_from_list(self):
-        self.sucessful_get_fogocruzado = get_fogocruzado(
-            city=["Rio de Janeiro", "Belford Roxo"]
-        )
-        self.assertTrue(
-            list(self.sucessful_get_fogocruzado.nome_cidade.unique())
-            == ["Rio de Janeiro", "Belford Roxo"]
+        with patch("crossfire.get_fogocruzado.extract_data_api") as mock:
+            mock.return_value = fake_api_data(
+                fake_api_row(nome_cidade="Rio de Janeiro"),
+                fake_api_row(nome_cidade="Niterói"),
+                fake_api_row(nome_cidade="Belford Roxo"),
+            )
+            sucessful_get_fogocruzado = get_fogocruzado(
+                city=["Rio de Janeiro", "Belford Roxo"]
+            )
+        self.assertEqual(
+            list(sucessful_get_fogocruzado.nome_cidade.unique()),
+            ["Rio de Janeiro", "Belford Roxo"],
         )
 
     def test_sucessful_filter_state_from_string(self):
-        self.sucessful_get_fogocruzado = get_fogocruzado(state="RJ")
-        self.assertTrue(self.sucessful_get_fogocruzado.uf_estado.unique()[0] == "RJ")
+        with patch("crossfire.get_fogocruzado.extract_data_api") as mock:
+            mock.return_value = fake_api_data(
+                fake_api_row(uf_estado="RJ"),
+                fake_api_row(uf_estado="PE"),
+            )
+            sucessful_get_fogocruzado = get_fogocruzado(state="RJ")
+            self.assertEqual(sucessful_get_fogocruzado.uf_estado.unique(), ["RJ"])
 
     def test_sucessful_filter_state_from_list(self):
-        self.sucessful_get_fogocruzado = get_fogocruzado(state=["RJ", "PE"])
-        self.assertTrue(
-            list(self.sucessful_get_fogocruzado.uf_estado.unique()) == ["RJ", "PE"]
-        )
+        with patch("crossfire.get_fogocruzado.extract_data_api") as mock:
+            mock.return_value = fake_api_data(
+                fake_api_row(uf_estado="RJ"),
+                fake_api_row(uf_estado="ES"),
+                fake_api_row(uf_estado="PE"),
+            )
+            sucessful_get_fogocruzado = get_fogocruzado(state=["RJ", "PE"])
+            self.assertEqual(
+                list(sucessful_get_fogocruzado.uf_estado.unique()), ["RJ", "PE"]
+            )
 
     def test_sucessful_filter_security_agent_from_string(self):
-        self.sucessful_get_fogocruzado = get_fogocruzado(security_agent=1)
-        self.assertTrue(
-            self.sucessful_get_fogocruzado.presen_agen_segur_ocorrencia.unique()[0] == 1
-        )
+        with patch("crossfire.get_fogocruzado.extract_data_api") as mock:
+            mock.return_value = fake_api_data(
+                fake_api_row(presen_agen_segur_ocorrencia=1),
+                fake_api_row(presen_agen_segur_ocorrencia=0),
+            )
+            sucessful_get_fogocruzado = get_fogocruzado(security_agent=1)
+            self.assertEqual(
+                sucessful_get_fogocruzado.presen_agen_segur_ocorrencia.unique(), [1]
+            )
 
     def test_sucessful_filter_security_agent_from_list(self):
-        self.sucessful_get_fogocruzado = get_fogocruzado(security_agent=[0, 1])
-        self.assertTrue(
-            list(self.sucessful_get_fogocruzado.presen_agen_segur_ocorrencia.unique())
-            == [0, 1]
-        )
+        with patch("crossfire.get_fogocruzado.extract_data_api") as mock:
+            mock.return_value = fake_api_data(
+                fake_api_row(presen_agen_segur_ocorrencia=2),
+                fake_api_row(presen_agen_segur_ocorrencia=0),
+                fake_api_row(presen_agen_segur_ocorrencia=1),
+            )
+            sucessful_get_fogocruzado = get_fogocruzado(security_agent=[0, 1])
+            self.assertEqual(
+                list(sucessful_get_fogocruzado.presen_agen_segur_ocorrencia.unique()),
+                [0, 1],
+            )


### PR DESCRIPTION
Depends on #7 (commit a8d0257d6f437c3906fbb3524ed5827beff0f05d belong there, but we needed it here in order for tests to pass — once that PR is merged the diff here will be clearer)

Closes #8 

Esse PR faz com que os testes passem independente de externalidades:
* Adiciona `pytest` para coletar todos os testes (ao invés de especificar um ou mais arquivos de testes)
* Remove dependência de variáveis de ambiente
* Remove dependência de API externa, substituindo-a por _mock_s
* Melhora sintaxe dos testes (por exemplo, evita `assertTrue(x == y)` preferindo `assertEqual(x, y)`)
* Evita colocar o objeto (função) testada no `setUp`
* Evita testar efeitos colaterais (por exemplo, o teste `fogocruzado_signin` dependia da lógica de `fogocruzado_key`)