### PR TITLE
Crie cliente para uso da API

### DIFF
--- a/Python/crossfire/crossfire/client.py
+++ b/Python/crossfire/crossfire/client.py
@@ -1,0 +1,62 @@
+from datetime import datetime, timedelta
+
+from decouple import UndefinedValueError, config
+from requests import post
+
+from crossfire.errors import CrossfireError
+
+
+class CredentialsNotFoundError(CrossfireError):
+    def __init__(self, key):
+        message = f"There's no enviornment variable `{key}` condigured."
+        super().__init__(message)
+
+
+class IncorrectCrdentialsError(CrossfireError):
+    pass
+
+
+class Token:
+    def __init__(self, value, expires_in):
+        self.value = value
+        self.valid_until = datetime.now() + timedelta(seconds=expires_in)
+
+    def is_valid(self):
+        return datetime.now() < self.valid_until
+
+
+class Client:
+    URL = "https://api-service.fogocruzado.org.br/api/v2/"
+
+    def __init__(self):
+        try:
+            self.email = config("FOGOCRUZADO_EMAIL")
+        except UndefinedValueError:
+            raise CredentialsNotFoundError("FOGOCRUZADO_EMAIL")
+
+        try:
+            self.password = config("FOGOCRUZADO_PASSWORD")
+        except UndefinedValueError:
+            raise CredentialsNotFoundError("FOGOCRUZADO_PASSWORD")
+
+        self.cached_token = None
+
+    @property
+    def token(self):
+        if self.cached_token and self.cached_token.is_valid():
+            return self.cached_token.value
+
+        url = f"{self.URL}auth/login"
+        resp = post(url, json={"email": self.email, "password": self.password})
+        if resp.status_code == 401:
+            data = resp.json()
+            raise IncorrectCrdentialsError(data["msg"])
+
+        if resp.status_code != 201:
+            resp.raise_for_status()
+
+        data = resp.json()
+        self.cached_token = Token(
+            data["data"]["accessToken"], data["data"]["expiresIn"]
+        )
+        return self.cached_token.value

--- a/Python/crossfire/crossfire/errors.py
+++ b/Python/crossfire/crossfire/errors.py
@@ -1,0 +1,2 @@
+class CrossfireError(Exception):
+    pass

--- a/Python/crossfire/tests/conftest.py
+++ b/Python/crossfire/tests/conftest.py
@@ -1,0 +1,12 @@
+from unittest.mock import patch
+
+from pytest import fixture
+
+from crossfire.client import Client
+
+
+@fixture
+def client():
+    with patch("crossfire.client.config") as mock:
+        mock.side_effect = ("email", "password")
+        yield Client()

--- a/Python/crossfire/tests/test_client.py
+++ b/Python/crossfire/tests/test_client.py
@@ -1,0 +1,84 @@
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+from decouple import UndefinedValueError
+from pytest import raises
+
+from crossfire.client import (
+    Client,
+    Token,
+    CredentialsNotFoundError,
+    IncorrectCrdentialsError,
+)
+
+DEFAULT_TOKEN_EXPIRES_IN = 3600
+AUTH_LOGIN_DATA = {
+    "data": {
+        "accessToken": "fourty-two",
+        "expiresIn": DEFAULT_TOKEN_EXPIRES_IN,
+    },
+}
+
+
+def test_client_initiates_with_proper_credentials(client):
+    assert client.email == "email"
+    assert client.password == "password"
+
+
+def test_client_does_not_initiate_with_proper_credentials():
+    with patch("crossfire.client.config") as mock:
+        mock.side_effect = UndefinedValueError()
+        with raises(CredentialsNotFoundError):
+            Client()
+
+
+def test_client_returns_a_token_when_cached_token_is_valid(client):
+    client.cached_token = Token("42", DEFAULT_TOKEN_EXPIRES_IN)
+    assert client.token == "42"
+
+
+def test_client_access_the_api_to_generate_token(client):
+    with patch("crossfire.client.post") as mock:
+        mock.return_value.json.return_value = AUTH_LOGIN_DATA
+        client.token  # tries to access the API to get the token
+        mock.assert_called_once_with(
+            "https://api-service.fogocruzado.org.br/api/v2/auth/login",
+            json={"email": client.email, "password": client.password},
+        )
+
+
+def test_client_raises_an_error_with_wrong_crdentials(client):
+    with patch("crossfire.client.post") as mock:
+        mock.return_value.status_code = 401
+        with raises(IncorrectCrdentialsError):
+            assert client.token
+
+
+def test_client_gets_new_token_from_api(client):
+    with patch("crossfire.client.post") as mock:
+        mock.return_value.status_code = 201
+        mock.return_value.json.return_value = AUTH_LOGIN_DATA
+
+        assert client.token == "fourty-two"
+        assert client.cached_token.valid_until <= datetime.now() + timedelta(
+            seconds=3600
+        )
+
+
+def test_client_propagates_error_when_fails_to_get_token(client):
+    with patch("crossfire.client.post") as mock:
+        mock.side_effect = Exception("Boom!")
+        with raises(Exception) as error:
+            client.token
+            assert str(error.value) == "Boom!"
+
+
+def test_client_goes_back_to_the_api_when_token_is_expired(client):
+    client.cached_token = Token("42", -DEFAULT_TOKEN_EXPIRES_IN)
+    with patch("crossfire.client.post") as mock:
+        mock.return_value.json.return_value = AUTH_LOGIN_DATA
+        client.token  # tries to access the API to get the token
+        mock.assert_called_once_with(
+            "https://api-service.fogocruzado.org.br/api/v2/auth/login",
+            json={"email": client.email, "password": client.password},
+        )


### PR DESCRIPTION
Esse PR cria um cliente para acesso da API. Ele abstrai a parte de autenticação e sempre retorna uma chave válida (dado que as variáveis de ambiente `FOGOCRUZADO_EMAIL` e `FOGOCRUZADO_PASSWORD` estejam configuradas corretamente):

```python
>>> from crossfire.client import Client
>>> client = Client()
>>> client.token
'ey…'
```

Também, o cliente controla a validade da chave e pede uma nova caso a atual tenha expirado.

Esse PR **não** utiliza esse cliente _ainda_. A ideia é em futuros PRs:

* [ ] substituir `fogocruzado_signin` e `fogocruzado_key` no código atual para obtenção da chave (_token_)<br>#14
* [ ] implementar um `client.occurrences()` para substituir o `get_fogocruzado`