### PR TITLE
adiciona kwargs ao Client() permitindo sobreescrever a variavel de ambiente com named_keys

### DIFF
--- a/Python/crossfire/crossfire/client.py
+++ b/Python/crossfire/crossfire/client.py
@@ -29,15 +29,18 @@ class Client:
     URL = "https://api-service.fogocruzado.org.br/api/v2/"
 
     def __init__(self, **kwargs):
-        try:
-            self.email = kwargs.get("email", config("FOGOCRUZADO_EMAIL"))
-        except UndefinedValueError:
-            raise CredentialsNotFoundError("FOGOCRUZADO_EMAIL")
-
-        try:
-            self.password = kwargs.get("password", config("FOGOCRUZADO_PASSWORD"))
-        except UndefinedValueError:
-            raise CredentialsNotFoundError("FOGOCRUZADO_PASSWORD")
+        self.email = kwargs.get("email")
+        self.password = kwargs.get("password")
+        if self.email is None:
+            try:
+                self.email = config("FOGOCRUZADO_EMAIL")
+            except UndefinedValueError:
+                raise CredentialsNotFoundError("FOGOCRUZADO_EMAIL")
+        if self.password is None:
+            try:
+                self.password = kwargs.get("password", config("FOGOCRUZADO_PASSWORD"))
+            except UndefinedValueError:
+                raise CredentialsNotFoundError("FOGOCRUZADO_PASSWORD")
 
         self.cached_token = None
 

--- a/Python/crossfire/crossfire/client.py
+++ b/Python/crossfire/crossfire/client.py
@@ -28,14 +28,14 @@ class Token:
 class Client:
     URL = "https://api-service.fogocruzado.org.br/api/v2/"
 
-    def __init__(self):
+    def __init__(self, **kwargs):
         try:
-            self.email = config("FOGOCRUZADO_EMAIL")
+            self.email = kwargs.get("email", config("FOGOCRUZADO_EMAIL"))
         except UndefinedValueError:
             raise CredentialsNotFoundError("FOGOCRUZADO_EMAIL")
 
         try:
-            self.password = config("FOGOCRUZADO_PASSWORD")
+            self.password = kwargs.get("password", config("FOGOCRUZADO_PASSWORD"))
         except UndefinedValueError:
             raise CredentialsNotFoundError("FOGOCRUZADO_PASSWORD")
 

--- a/Python/crossfire/tests/test_client.py
+++ b/Python/crossfire/tests/test_client.py
@@ -31,6 +31,13 @@ def test_client_does_not_initiate_with_proper_credentials():
             Client()
 
 
+def test_client_initiates_with_credentials_from_kwargs():
+    credentials_kwargs = {"email": "email.kwargs", "password": "password.kwargs"}
+    client = Client(**credentials_kwargs)
+    assert client.email == "email.kwargs"
+    assert client.password == "password.kwargs"
+
+
 def test_client_returns_a_token_when_cached_token_is_valid(client_with_token):
     assert client_with_token.token == "42"
 


### PR DESCRIPTION
Adiciona a possibilidade de passar as credenciais `email` e `password`, para autentiação do [`Client`](), a partir de named_keys, sobreescrevendo as credenciais definidas por variáveis de ambiente. 