### PR TITLE
Adiciona a chamada de UF no cliente da API

### DIFF
--- a/Python/crossfire/crossfire/client.py
+++ b/Python/crossfire/crossfire/client.py
@@ -1,11 +1,16 @@
-from functools import cached_property
 from datetime import datetime, timedelta
 
 from decouple import UndefinedValueError, config
-from pandas import DataFrame
 from requests import get, post
 
 from crossfire.errors import CrossfireError
+
+try:
+    from pandas import DataFrame
+
+    HAS_PANDAS = True
+except ModuleNotFoundError:
+    HAS_PANDAS = False
 
 
 URL = "https://api-service.fogocruzado.org.br/api/v2"
@@ -49,7 +54,7 @@ def parse_response(method):
         contents = response.json()
         data = contents.get("data", [])
 
-        if self.has_pandas and format in ("df", None):
+        if HAS_PANDAS and format in ("df", None):
             return DataFrame(data)
 
         return data
@@ -73,14 +78,6 @@ class Client:
                 raise CredentialsNotFoundError("FOGOCRUZADO_PASSWORD")
 
         self.cached_token = None
-
-    @cached_property
-    def has_pandas(self):
-        try:
-            DataFrame
-        except NameError:
-            return False
-        return True
 
     @property
     def token(self):

--- a/Python/crossfire/crossfire/client.py
+++ b/Python/crossfire/crossfire/client.py
@@ -82,6 +82,9 @@ class Client:
 
         return get(*args, **kwargs)
 
-    def states(self):
+    def states(self, as_dataframe=True):
         resp = self.get(f"{self.URL}states")
-        return to_dataframe(resp)
+        if as_dataframe:
+            return to_dataframe(resp)
+
+        return resp.json().get("data", [])

--- a/Python/crossfire/crossfire/fogocruzado_utils.py
+++ b/Python/crossfire/crossfire/fogocruzado_utils.py
@@ -1,7 +1,7 @@
 import logging
 from functools import lru_cache
 
-from crossfire.client import Client, to_dataframe
+from crossfire.client import Client
 
 
 @lru_cache(maxsize=1)
@@ -20,8 +20,7 @@ def extract_data_api(link):
     """
     logging.info("Extracting data from Fogo Cruzado's API...")
     client = load_client()
-    resp = client.get(url=link)
-    return to_dataframe(resp)
+    return client.get(link)
 
 
 def extract_cities_api():
@@ -31,7 +30,4 @@ def extract_cities_api():
     :return: pandas.DataFrame
         Result from the request API in pandas DataFrame format
     """
-    logging.info("Extracting data from Fogo Cruzado's API...")
-    client = load_client()
-    resp = client.get(url="https://api.fogocruzado.org.br/api/v1/cities")
-    return to_dataframe(resp)
+    return extract_data_api("https://api.fogocruzado.org.br/api/v1/cities")

--- a/Python/crossfire/crossfire/fogocruzado_utils.py
+++ b/Python/crossfire/crossfire/fogocruzado_utils.py
@@ -1,18 +1,12 @@
 import logging
 from functools import lru_cache
-from pandas import DataFrame
 
-from crossfire.client import Client
+from crossfire.client import Client, to_dataframe
 
 
 @lru_cache(maxsize=1)
 def load_client():
     return Client()
-
-
-def to_dataframe(resp):
-    resp.encoding = "utf8"
-    return DataFrame(resp.json())
 
 
 def extract_data_api(link):

--- a/Python/crossfire/tests/test_client.py
+++ b/Python/crossfire/tests/test_client.py
@@ -115,3 +115,17 @@ def test_client_load_states(client_with_token):
         )
         assert states.shape == (1, 2)
         assert states.name[0] == "Rio de Janeiro"
+
+
+def test_client_load_states_as_python(client_with_token):
+    with patch("crossfire.client.get") as mock:
+        mock.return_value.json.return_value = {
+            "data": [{"id": "42", "name": "Rio de Janeiro"}]
+        }
+        states = client_with_token.states(as_dataframe=False)
+        mock.assert_called_once_with(
+            "https://api-service.fogocruzado.org.br/api/v2/states",
+            headers={"Authorization": "Bearer 42"},
+        )
+        assert len(states) == 1
+        assert states[0]["name"] == "Rio de Janeiro"

--- a/Python/crossfire/tests/test_client.py
+++ b/Python/crossfire/tests/test_client.py
@@ -92,12 +92,26 @@ def test_client_goes_back_to_the_api_when_token_is_expired(client):
 def test_client_inserts_auth_header_on_http_get(client_with_token):
     with patch("crossfire.client.get") as mock:
         client_with_token.get("my-url")
-        mock.assert_called_once_with("my-url", headers={"Authorization": "42"})
+        mock.assert_called_once_with("my-url", headers={"Authorization": "Bearer 42"})
 
 
 def test_client_inserts_auth_header_on_http_get_without_overwriting(client_with_token):
     with patch("crossfire.client.get") as mock:
         client_with_token.get("my-url", headers={"answer": "fourty-two"})
         mock.assert_called_once_with(
-            "my-url", headers={"Authorization": "42", "answer": "fourty-two"}
+            "my-url", headers={"Authorization": "Bearer 42", "answer": "fourty-two"}
         )
+
+
+def test_client_load_states(client_with_token):
+    with patch("crossfire.client.get") as mock:
+        mock.return_value.json.return_value = {
+            "data": [{"id": "42", "name": "Rio de Janeiro"}]
+        }
+        states = client_with_token.states()
+        mock.assert_called_once_with(
+            "https://api-service.fogocruzado.org.br/api/v2/states",
+            headers={"Authorization": "Bearer 42"},
+        )
+        assert states.shape == (1, 2)
+        assert states.name[0] == "Rio de Janeiro"

--- a/Python/crossfire/tests/test_client.py
+++ b/Python/crossfire/tests/test_client.py
@@ -6,9 +6,10 @@ from pytest import raises
 
 from crossfire.client import (
     Client,
-    Token,
     CredentialsNotFoundError,
     IncorrectCrdentialsError,
+    Token,
+    UnknownFormatError,
 )
 
 AUTH_LOGIN_DATA = {
@@ -117,12 +118,19 @@ def test_client_load_states(client_with_token):
         assert states.name[0] == "Rio de Janeiro"
 
 
-def test_client_load_states_as_python(client_with_token):
+def test_client_load_states_raises_format_error(client_with_token):
+    with patch("crossfire.client.get") as mock:
+        mock.return_value.json.return_value = {"data": []}
+        with raises(UnknownFormatError):
+            client_with_token.states(format="parquet")
+
+
+def test_client_load_states_as_dictionary(client_with_token):
     with patch("crossfire.client.get") as mock:
         mock.return_value.json.return_value = {
             "data": [{"id": "42", "name": "Rio de Janeiro"}]
         }
-        states = client_with_token.states(as_dataframe=False)
+        states = client_with_token.states(format="dict")
         mock.assert_called_once_with(
             "https://api-service.fogocruzado.org.br/api/v2/states",
             headers={"Authorization": "Bearer 42"},

--- a/Python/crossfire/tests/test_crossfire.py
+++ b/Python/crossfire/tests/test_crossfire.py
@@ -29,8 +29,8 @@ def fake_api_data(*rows):
 
 class TestExtractDataAPI(TestCase):
     def test_extract_data_api(self):
-        with patch("crossfire.fogocruzado_utils.load_client") as mock:
-            mock.return_value.get.return_value.json.return_value = []
+        with patch("crossfire.fogocruzado_utils.to_dataframe") as mock:
+            mock.return_value = DataFrame()
             data = extract_data_api(
                 link="https://api.fogocruzado.org.br/api/v1/occurrences?data_ocorrencia[gt]=2020-01-01&data_ocorrencia[lt]=2020-02-01"
             )
@@ -39,8 +39,8 @@ class TestExtractDataAPI(TestCase):
 
 class TestExtractCitiesAPI(TestCase):
     def test_extract_cities_api(self):
-        with patch("crossfire.fogocruzado_utils.load_client") as mock:
-            mock.return_value.get.return_value.json.return_value = []
+        with patch("crossfire.fogocruzado_utils.to_dataframe") as mock:
+            mock.return_value = DataFrame()
             data = extract_cities_api()
         self.assertIsInstance(data, DataFrame)
 

--- a/Python/crossfire/tests/test_crossfire.py
+++ b/Python/crossfire/tests/test_crossfire.py
@@ -2,11 +2,11 @@ from datetime import date
 from unittest import TestCase
 from unittest.mock import patch
 
-from crossfire.fogocruzado_utils import extract_data_api, extract_cities_api
-
-from crossfire.load_data import InvalidDateIntervalError, get_fogocruzado
 from geopandas import GeoDataFrame
 from pandas import DataFrame
+
+from crossfire.fogocruzado_utils import extract_data_api, extract_cities_api
+from crossfire.load_data import InvalidDateIntervalError, get_fogocruzado
 
 
 def fake_api_row(**extra_fields):
@@ -29,18 +29,22 @@ def fake_api_data(*rows):
 
 class TestExtractDataAPI(TestCase):
     def test_extract_data_api(self):
-        with patch("crossfire.fogocruzado_utils.Client") as client:
-            client.return_value.get.return_value.json.return_value = {"data": []}
+        with patch("crossfire.fogocruzado_utils.load_client") as mock:
+            mock.return_value.get.return_value = DataFrame()
             data = extract_data_api(
-                link="https://api.fogocruzado.org.br/api/v1/occurrences?data_ocorrencia[gt]=2020-01-01&data_ocorrencia[lt]=2020-02-01"
+                (
+                    "https://api.fogocruzado.org.br/api/v1/occurrences"
+                    "?data_ocorrencia[gt]=2020-01-01"
+                    "&data_ocorrencia[lt]=2020-02-01"
+                )
             )
         self.assertIsInstance(data, DataFrame)
 
 
 class TestExtractCitiesAPI(TestCase):
     def test_extract_cities_api(self):
-        with patch("crossfire.fogocruzado_utils.Client") as client:
-            client.return_value.get.return_value.json.return_value = {"data": []}
+        with patch("crossfire.fogocruzado_utils.load_client") as mock:
+            mock.return_value.get.return_value = DataFrame()
             data = extract_cities_api()
         self.assertIsInstance(data, DataFrame)
 

--- a/Python/crossfire/tests/test_crossfire.py
+++ b/Python/crossfire/tests/test_crossfire.py
@@ -29,7 +29,9 @@ def fake_api_data(*rows):
 
 class TestExtractDataAPI(TestCase):
     def test_extract_data_api(self):
-        with patch("crossfire.fogocruzado_utils.to_dataframe") as mock:
+        with patch("crossfire.fogocruzado_utils.Client"), patch(
+            "crossfire.fogocruzado_utils.to_dataframe"
+        ) as mock:
             mock.return_value = DataFrame()
             data = extract_data_api(
                 link="https://api.fogocruzado.org.br/api/v1/occurrences?data_ocorrencia[gt]=2020-01-01&data_ocorrencia[lt]=2020-02-01"
@@ -39,7 +41,9 @@ class TestExtractDataAPI(TestCase):
 
 class TestExtractCitiesAPI(TestCase):
     def test_extract_cities_api(self):
-        with patch("crossfire.fogocruzado_utils.to_dataframe") as mock:
+        with patch("crossfire.fogocruzado_utils.Client"), patch(
+            "crossfire.fogocruzado_utils.to_dataframe"
+        ) as mock:
             mock.return_value = DataFrame()
             data = extract_cities_api()
         self.assertIsInstance(data, DataFrame)

--- a/Python/crossfire/tests/test_crossfire.py
+++ b/Python/crossfire/tests/test_crossfire.py
@@ -29,10 +29,8 @@ def fake_api_data(*rows):
 
 class TestExtractDataAPI(TestCase):
     def test_extract_data_api(self):
-        with patch("crossfire.fogocruzado_utils.Client"), patch(
-            "crossfire.fogocruzado_utils.to_dataframe"
-        ) as mock:
-            mock.return_value = DataFrame()
+        with patch("crossfire.fogocruzado_utils.Client") as client:
+            client.return_value.get.return_value.json.return_value = {"data": []}
             data = extract_data_api(
                 link="https://api.fogocruzado.org.br/api/v1/occurrences?data_ocorrencia[gt]=2020-01-01&data_ocorrencia[lt]=2020-02-01"
             )
@@ -41,10 +39,8 @@ class TestExtractDataAPI(TestCase):
 
 class TestExtractCitiesAPI(TestCase):
     def test_extract_cities_api(self):
-        with patch("crossfire.fogocruzado_utils.Client"), patch(
-            "crossfire.fogocruzado_utils.to_dataframe"
-        ) as mock:
-            mock.return_value = DataFrame()
+        with patch("crossfire.fogocruzado_utils.Client") as client:
+            client.return_value.get.return_value.json.return_value = {"data": []}
             data = extract_cities_api()
         self.assertIsInstance(data, DataFrame)
 


### PR DESCRIPTION
Esse PR adiciona o _endpoint_ `states` ao cliente da API:hon

```python
>>> from crossfire.client import Client
>>> client = Client()
>>> states = client.states()
>>> states
                                     id            name
0  b112ffbe-17b3-4ad0-8f2a-2038745d1d14  Rio de Janeiro
1  813ca36b-91e3-4a18-b408-60b27a1942ef      Pernambuco
2  d3a9b545-7056-4dc6-9b68-ce320c9edffc           Bahia
>>> 
```

E adiciona a opção para _não_ utilizar o Pandas caso não seja desejado:

```python
>>> from crossfire.client import Client
>>> client = Client()
>>> states = client.states(format='dict')
>>> states
[{'id': 'b112ffbe-17b3-4ad0-8f2a-2038745d1d14', 'name': 'Rio de Janeiro'}, {'id': '813ca36b-91e3-4a18-b408-60b27a1942ef', 'name': 'Pernambuco'}, {'id': 'd3a9b545-7056-4dc6-9b68-ce320c9edffc', 'name': 'Bahia'}]
```

No caminho:
* Corrige autenticação (faltava o `Bearer` no cabeçalho)
* Move a função auxiliar `to_dataframe` para o módulo do cliente (creio que o `load_data` deve sumir já já)
* Arruma o `to_dataframe` (retorna um `DataFrame` com os dados de `data` na resposta, não com a resposta toda)