### PR TITLE
Cria testes para a classe `Occurences`

### DIFF
--- a/Python/crossfire/tests/test_occurences.py
+++ b/Python/crossfire/tests/test_occurences.py
@@ -1,0 +1,43 @@
+from unittest.mock import Mock, call
+
+from fogocruzado.occurences import Occurences
+
+
+def dummy_response(last_page=False):
+    return {
+        "pageMeta": {
+            "hasNextPage": not last_page,
+        },
+        "data": [
+            {
+                "id": "a7bfebed-ce9c-469d-a656-924ed8248e95",
+                "latitude": "-8.1576367000",
+                "longitude": "-34.9696372000",
+            },
+            {
+                "id": "a14d18dd-b28f-4c30-af07-5fa40d88b3f7",
+                "latitude": "-7.9800434000",
+                "longitude": "-35.0553350000",
+            },
+        ],
+    }
+
+
+def test_occurences_from_at_least_two_pages():
+    client = Mock()
+    client.get.return_value.json.return_value = dummy_response()
+    generator = Occurences(client)
+    occurences = tuple(occ for count, occ in enumerate(generator, 1) if count <= 3)
+    assert client.get.call_count == 2
+    assert len(occurences) == 3
+
+
+def test_occurences_stops_when_there_are_no_more_pages():
+    client = Mock()
+    client.get.return_value.json.side_effect = (
+        dummy_response(False),
+        dummy_response(True),
+    )
+    occurences = tuple(occurence for occurence in Occurences(client))
+    assert client.get.call_count == 2
+    assert len(occurences) == 4


### PR DESCRIPTION
Esse PR sugere dois testes básicos para colaborar com o #31 ao estilo TDD — seguir a direção que esses testes sugerem ajudaria no progresso da implementação.

(Repare que o PR adiciona o código à `add_client_occurences` ao invés de `master` 😉 )