### PR TITLE
Altera `parse_response` para retornar informação sobre paginação

### DIFF
--- a/Python/crossfire/crossfire/parser.py
+++ b/Python/crossfire/crossfire/parser.py
@@ -39,6 +39,7 @@ def parse_response(method):
         response = method(self, *args, **kwargs)
         response.encoding = "utf8"
         contents = response.json()
+        has_next_page = contents.get("pageMeta", {}).get("hasNextPage", False)
         data = contents.get("data", [])
 
         if HAS_GEOPANDAS and format == "geodf":
@@ -50,11 +51,11 @@ def parse_response(method):
                 )
 
             geometry = points_from_xy(df.longitude_ocorrencia, df.latitude_ocorrencia)
-            return GeoDataFrame(df, geometry=geometry, crs=CRS)
+            return GeoDataFrame(df, geometry=geometry, crs=CRS), has_next_page
 
         if HAS_PANDAS and format == "df":
-            return DataFrame(data)
+            return DataFrame(data), has_next_page
 
-        return data
+        return data, has_next_page
 
     return wrapper

--- a/Python/crossfire/tests/test_client.py
+++ b/Python/crossfire/tests/test_client.py
@@ -125,7 +125,7 @@ def test_client_load_states(client_with_token):
         mock.return_value.json.return_value = {
             "data": [{"id": "42", "name": "Rio de Janeiro"}]
         }
-        states = client_with_token.states()
+        states, _ = client_with_token.states()
         mock.assert_called_once_with(
             "https://api-service.fogocruzado.org.br/api/v2/states",
             headers={"Authorization": "Bearer 42"},
@@ -139,7 +139,7 @@ def test_client_load_states_as_df(client_with_token):
         mock.return_value.json.return_value = {
             "data": [{"id": "42", "name": "Rio de Janeiro"}]
         }
-        states = client_with_token.states(format="df")
+        states, _ = client_with_token.states(format="df")
         mock.assert_called_once_with(
             "https://api-service.fogocruzado.org.br/api/v2/states",
             headers={"Authorization": "Bearer 42"},
@@ -158,7 +158,7 @@ def test_client_load_states_raises_format_error(client_with_token):
 def test_client_load_cities(client_with_token):
     with patch("crossfire.client.get") as mock:
         mock.return_value.json.return_value = {"data": fake_cities_api_row()}
-        cities = client_with_token.cities()
+        cities, _ = client_with_token.cities()
         mock.assert_called_once_with(
             "https://api-service.fogocruzado.org.br/api/v2/cities?",
             headers={"Authorization": "Bearer 42"},
@@ -170,7 +170,7 @@ def test_client_load_cities(client_with_token):
 def test_client_load_cities_as_dictionary(client_with_token):
     with patch("crossfire.client.get") as mock:
         mock.return_value.json.return_value = {"data": fake_cities_api_row()}
-        cities = client_with_token.cities(format="dict")
+        cities, _ = client_with_token.cities(format="dict")
         mock.assert_called_once_with(
             "https://api-service.fogocruzado.org.br/api/v2/cities?",
             headers={"Authorization": "Bearer 42"},

--- a/Python/crossfire/tests/test_parser.py
+++ b/Python/crossfire/tests/test_parser.py
@@ -34,19 +34,19 @@ def test_parse_response_raises_error_for_unknown_format():
 
 def test_parse_response_uses_dict_by_default():
     client = DummyClient()
-    data = client.get()
+    data, _ = client.get()
     assert isinstance(data, list)
 
 
 def test_parse_response_uses_dataframe_when_specified():
     client = DummyClient()
-    data = client.get(format="df")
+    data, _ = client.get(format="df")
     assert isinstance(data, DataFrame)
 
 
 def test_parse_response_uses_geodataframe_when_specified():
     client = DummyClient(geo=True)
-    data = client.get(geo=True, format="geodf")
+    data, _ = client.get(geo=True, format="geodf")
     assert isinstance(data, GeoDataFrame)
 
 


### PR DESCRIPTION
@cuducos implemento aqui a sua primeira proposta de alterar o `parse_response` para retornar dado e paginação.