### PR TITLE
Altera `Client.states()` e `Client.cities()` para não retornar informação sobre paginação

### DIFF
--- a/Python/crossfire/crossfire/client.py
+++ b/Python/crossfire/crossfire/client.py
@@ -80,10 +80,18 @@ class Client:
 
         return get(*args, **kwargs)
 
-    def states(self, format=None):
+    def _states(self, format=None):
         return self.get(f"{self.URL}/states", format=format)
 
-    def cities(self, city_id=None, city_name=None, state_id=None, format=None):
+    def states(self, *args, **kwargs):
+        states, _ = self._states(*args, **kwargs)
+        return states
+
+    def _cities(self, city_id=None, city_name=None, state_id=None, format=None):
         params = {"cityId": city_id, "cityName": city_name, "stateId": state_id}
         cleaned = urlencode({key: value for key, value in params.items() if value})
         return self.get(f"{self.URL}/cities?{cleaned}", format=format)
+
+    def cities(self, *args, **kwargs):
+        cities, _ = self._cities(*args, **kwargs)
+        return cities

--- a/Python/crossfire/tests/test_client.py
+++ b/Python/crossfire/tests/test_client.py
@@ -125,7 +125,7 @@ def test_client_load_states(client_with_token):
         mock.return_value.json.return_value = {
             "data": [{"id": "42", "name": "Rio de Janeiro"}]
         }
-        states, _ = client_with_token.states()
+        states = client_with_token.states()
         mock.assert_called_once_with(
             "https://api-service.fogocruzado.org.br/api/v2/states",
             headers={"Authorization": "Bearer 42"},
@@ -139,7 +139,7 @@ def test_client_load_states_as_df(client_with_token):
         mock.return_value.json.return_value = {
             "data": [{"id": "42", "name": "Rio de Janeiro"}]
         }
-        states, _ = client_with_token.states(format="df")
+        states = client_with_token.states(format="df")
         mock.assert_called_once_with(
             "https://api-service.fogocruzado.org.br/api/v2/states",
             headers={"Authorization": "Bearer 42"},
@@ -158,7 +158,7 @@ def test_client_load_states_raises_format_error(client_with_token):
 def test_client_load_cities(client_with_token):
     with patch("crossfire.client.get") as mock:
         mock.return_value.json.return_value = {"data": fake_cities_api_row()}
-        cities, _ = client_with_token.cities()
+        cities = client_with_token.cities()
         mock.assert_called_once_with(
             "https://api-service.fogocruzado.org.br/api/v2/cities?",
             headers={"Authorization": "Bearer 42"},
@@ -170,7 +170,7 @@ def test_client_load_cities(client_with_token):
 def test_client_load_cities_as_dictionary(client_with_token):
     with patch("crossfire.client.get") as mock:
         mock.return_value.json.return_value = {"data": fake_cities_api_row()}
-        cities, _ = client_with_token.cities(format="dict")
+        cities = client_with_token.cities(format="dict")
         mock.assert_called_once_with(
             "https://api-service.fogocruzado.org.br/api/v2/cities?",
             headers={"Authorization": "Bearer 42"},


### PR DESCRIPTION
Conforme mencionado na issue #36 : este PR altera os métodos `Client.states()` e `Client.cities() adicionando uma abstração que desconsidera a informação de paginação.

Com isso usuário final poderá usar-los sem se preocupar em criar um objeto para paginação.