### PR TITLE
Altera `Occurrences` permitindo passar lilsta de `id_cities`

### DIFF
--- a/Python/crossfire/crossfire/client.py
+++ b/Python/crossfire/crossfire/client.py
@@ -87,3 +87,20 @@ class Client:
         params = {"cityId": city_id, "cityName": city_name, "stateId": state_id}
         cleaned = urlencode({key: value for key, value in params.items() if value})
         return self.get(f"{self.URL}/cities?{cleaned}", format=format)
+
+    def occurrences(
+        self,
+        city_id=None,
+        state_id=None,
+        initial_date=None,
+        final_date=None,
+        format=None,
+    ):
+        params = {
+            "idCities": city_id,
+            "idState": state_id,
+            "initialdate": initial_date,
+            "finaldate": final_date,
+        }
+        cleaned = urlencode({key: value for key, value in params.items() if value})
+        return self.get(f"{self.URL}/occurrences?{cleaned}", format=format)

--- a/Python/crossfire/crossfire/occurrences.py
+++ b/Python/crossfire/crossfire/occurrences.py
@@ -3,15 +3,21 @@ from urllib.parse import urlencode
 
 
 class Occurrences:
-    def __init__(self, client):
+    def __init__(self, client, id_state, id_cities, format):
         self.client = client
         self.buffer = Queue()
+        self.id_state = id_state
+        self.id_cities = id_cities
+        self.next_page = 1
+        self.format = format
 
     def __iter__(self):
         return self
 
     def __next__(self):
         if self.buffer.empty():
+            if not self.next_page:
+                raise StopIteration
             self.load_occurrences()
 
         try:
@@ -21,15 +27,26 @@ class Occurrences:
 
         return occurrence
 
-    def load_occurrences(self, id_state=None, id_cities=None, format=None):
-        params = {"idState": id_state, "idCities": id_cities}
-        cleaned = urlencode({key: value for key, value in params.items() if value})
-        occurrences, has_next_page = self.client.get(
-            f"{self.client.URL}/occurrences?{cleaned}"
+    def load_occurrences(self):
+        if not self.next_page:
+            return
+
+        params = {
+            "idState": self.id_state,
+            "idCities": self.id_cities,
+            "page": self.next_page,
+        }
+        cleaned_params = urlencode(
+            {key: value for key, value in params.items() if value}
         )
-        if has_next_page:
-            pass
-            # return self.client.get(f"{self.client.URL}/occurrences?{cleaned}", format)
+        occurrences, has_next_page = self.client.get(
+            f"{self.client.URL}/occurrences?{cleaned_params}"
+        )
 
         for occurrence in occurrences:
             self.buffer.put(occurrence)
+
+        if has_next_page:
+            self.next_page += 1
+        else:
+            self.next_page = None

--- a/Python/crossfire/crossfire/occurrences.py
+++ b/Python/crossfire/crossfire/occurrences.py
@@ -3,13 +3,19 @@ from urllib.parse import urlencode
 
 
 class Occurrences:
-    def __init__(self, client, id_state, id_cities, format):
+    def __init__(self, client, id_state, id_cities=None, format=None):
         self.client = client
-        self.buffer = Queue()
         self.id_state = id_state
         self.id_cities = id_cities
-        self.next_page = 1
         self.format = format
+
+        self.buffer = Queue()
+        self.next_page = 1
+
+        self.params = {
+            "idState": self.id_state,
+            "idCities": self.id_cities,
+        }
 
     def __iter__(self):
         return self
@@ -31,13 +37,9 @@ class Occurrences:
         if not self.next_page:
             return
 
-        params = {
-            "idState": self.id_state,
-            "idCities": self.id_cities,
-            "page": self.next_page,
-        }
+        self.params.update({"page": self.next_page})
         cleaned_params = urlencode(
-            {key: value for key, value in params.items() if value}
+            {key: value for key, value in self.params.items() if value}
         )
         occurrences, has_next_page = self.client.get(
             f"{self.client.URL}/occurrences?{cleaned_params}"

--- a/Python/crossfire/crossfire/occurrences.py
+++ b/Python/crossfire/crossfire/occurrences.py
@@ -14,19 +14,16 @@ class Occurrences:
             self.load_occurrences()
 
         try:
-            occurrences = self.buffer.get_nowait()
+            occurrence = self.buffer.get_nowait()
         except Empty:
             raise StopIteration
 
-        return occurrences
+        return occurrence
 
     def load_occurrences(self):
-        occurrences = self.client.get(
-            "https://api-service.fogocruzado.org.br/api/v2/occurrences?"
-        )
-        if occurrences.get("pageMeta", {}).get("hasNextPage"):
-            return self.client.get(
-                "https://api-service.fogocruzado.org.br/api/v2/occurrences?"
-            )
+        occurrences, has_next_page = self.client.get(f"{self.client.URL}/occurrences")
+        if has_next_page:
+            return self.client.get(f"{self.client.URL}/occurrences")
 
-        return self.buffer.put(occurrences.get("data"))
+        for occurrence in occurrences:
+            self.buffer.put(occurrence)

--- a/Python/crossfire/crossfire/occurrences.py
+++ b/Python/crossfire/crossfire/occurrences.py
@@ -10,11 +10,14 @@ class Occurrences:
         self.buffer = Queue()
         self.next_page = 1
 
-        self.params = {
-            key: value
-            for key, value in {"idState": id_state, "idCities": id_cities}.items()
-            if value
-        }
+        self.params = [("idState", id_state)]
+        if id_cities is not None:
+            if isinstance(id_cities, list):
+                id_cities = [("idCities", city) for city in id_cities]
+            else:
+                id_cities = [("idCities", id_cities)]
+            self.params.extend(id_cities)
+        self.urlbase = f"{self.client.URL}/occurrences?{urlencode(self.params)}"
 
     def __iter__(self):
         return self
@@ -36,9 +39,8 @@ class Occurrences:
         if not self.next_page:
             return
 
-        self.params["page"] = self.next_page
         occurrences, has_next_page = self.client.get(
-            f"{self.client.URL}/occurrences?{urlencode(self.params)}"
+            f"{self.urlbase}&{urlencode({'page': self.next_page})}"
         )
 
         for occurrence in occurrences:

--- a/Python/crossfire/crossfire/occurrences.py
+++ b/Python/crossfire/crossfire/occurrences.py
@@ -10,15 +10,14 @@ class Occurrences:
     def __iter__(self):
         return self
 
-    def __next__(self):  # __next__ takes no argument, see https://docs.python.org/3/library/stdtypes.html#iterator.__next__
+    def __next__(self):
         if self.buffer.empty():
             self.load_occurrences()
 
         try:
             occurrence = self.buffer.get_nowait()
         except Empty:
-            occurrence = None
-            raise StopIteration  # as mentioned above
+            raise StopIteration
 
         return occurrence
 

--- a/Python/crossfire/crossfire/occurrences.py
+++ b/Python/crossfire/crossfire/occurrences.py
@@ -1,4 +1,5 @@
 from queue import Empty, Queue
+from urllib.parse import urlencode
 
 
 class Occurrences:
@@ -20,10 +21,15 @@ class Occurrences:
 
         return occurrence
 
-    def load_occurrences(self):
-        occurrences, has_next_page = self.client.get(f"{self.client.URL}/occurrences")
+    def load_occurrences(self, id_state=None, id_cities=None, format=None):
+        params = {"idState": id_state, "idCities": id_cities}
+        cleaned = urlencode({key: value for key, value in params.items() if value})
+        occurrences, has_next_page = self.client.get(
+            f"{self.client.URL}/occurrences?{cleaned}"
+        )
         if has_next_page:
-            return self.client.get(f"{self.client.URL}/occurrences")
+            pass
+            # return self.client.get(f"{self.client.URL}/occurrences?{cleaned}", format)
 
         for occurrence in occurrences:
             self.buffer.put(occurrence)

--- a/Python/crossfire/crossfire/occurrences.py
+++ b/Python/crossfire/crossfire/occurrences.py
@@ -5,16 +5,14 @@ from urllib.parse import urlencode
 class Occurrences:
     def __init__(self, client, id_state, id_cities=None, format=None):
         self.client = client
-        self.id_state = id_state
-        self.id_cities = id_cities
         self.format = format
 
         self.buffer = Queue()
         self.next_page = 1
 
         self.params = {
-            "idState": self.id_state,
-            "idCities": self.id_cities,
+            "idState": id_state,
+            "idCities": id_cities,
         }
 
     def __iter__(self):
@@ -37,7 +35,7 @@ class Occurrences:
         if not self.next_page:
             return
 
-        self.params.update({"page": self.next_page})
+        self.params["page"] = self.next_page
         cleaned_params = urlencode(
             {key: value for key, value in self.params.items() if value}
         )

--- a/Python/crossfire/crossfire/occurrences.py
+++ b/Python/crossfire/crossfire/occurrences.py
@@ -1,5 +1,4 @@
 from queue import Queue, Empty
-import random
 
 
 class Occurrences:
@@ -15,11 +14,19 @@ class Occurrences:
             self.load_occurrences()
 
         try:
-            occurrence = self.buffer.get_nowait()
+            occurrences = self.buffer.get_nowait()
         except Empty:
             raise StopIteration
 
-        return occurrence
+        return occurrences
 
     def load_occurrences(self):
-        return self.buffer.put(random.random())
+        occurrences = self.client.get(
+            "https://api-service.fogocruzado.org.br/api/v2/occurrences?"
+        )
+        if occurrences.get("pageMeta", {}).get("hasNextPage"):
+            return self.client.get(
+                "https://api-service.fogocruzado.org.br/api/v2/occurrences?"
+            )
+
+        return self.buffer.put(occurrences.get("data"))

--- a/Python/crossfire/crossfire/occurrences.py
+++ b/Python/crossfire/crossfire/occurrences.py
@@ -1,0 +1,26 @@
+from queue import Queue, Empty
+import random
+
+
+class Occurrences:
+    def __init__(self, client):
+        self.client = client
+        self.buffer = Queue()
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):  # __next__ takes no argument, see https://docs.python.org/3/library/stdtypes.html#iterator.__next__
+        if self.buffer.empty():
+            self.load_occurrences()
+
+        try:
+            occurrence = self.buffer.get_nowait()
+        except Empty:
+            occurrence = None
+            raise StopIteration  # as mentioned above
+
+        return occurrence
+
+    def load_occurrences(self):
+        return self.buffer.put(random.random())

--- a/Python/crossfire/crossfire/occurrences.py
+++ b/Python/crossfire/crossfire/occurrences.py
@@ -11,8 +11,9 @@ class Occurrences:
         self.next_page = 1
 
         self.params = {
-            "idState": id_state,
-            "idCities": id_cities,
+            key: value
+            for key, value in {"idState": id_state, "idCities": id_cities}.items()
+            if value
         }
 
     def __iter__(self):
@@ -36,11 +37,8 @@ class Occurrences:
             return
 
         self.params["page"] = self.next_page
-        cleaned_params = urlencode(
-            {key: value for key, value in self.params.items() if value}
-        )
         occurrences, has_next_page = self.client.get(
-            f"{self.client.URL}/occurrences?{cleaned_params}"
+            f"{self.client.URL}/occurrences?{urlencode(self.params)}"
         )
 
         for occurrence in occurrences:

--- a/Python/crossfire/tests/test_occurences.py
+++ b/Python/crossfire/tests/test_occurences.py
@@ -1,6 +1,6 @@
-from unittest.mock import Mock, call
+from unittest.mock import Mock
 
-from fogocruzado.occurences import Occurences
+from crossfire.occurrences import Occurrences
 
 
 def dummy_response(last_page=False):
@@ -23,21 +23,21 @@ def dummy_response(last_page=False):
     }
 
 
-def test_occurences_from_at_least_two_pages():
+def test_occurrences_from_at_least_two_pages():
     client = Mock()
     client.get.return_value.json.return_value = dummy_response()
-    generator = Occurences(client)
-    occurences = tuple(occ for count, occ in enumerate(generator, 1) if count <= 3)
+    generator = Occurrences(client)
+    occurrences = tuple(occ for count, occ in enumerate(generator, 1) if count <= 3)
     assert client.get.call_count == 2
-    assert len(occurences) == 3
+    assert len(occurrences) == 3
 
 
-def test_occurences_stops_when_there_are_no_more_pages():
+def test_occurrences_stops_when_there_are_no_more_pages():
     client = Mock()
     client.get.return_value.json.side_effect = (
         dummy_response(False),
         dummy_response(True),
     )
-    occurences = tuple(occurence for occurence in Occurences(client))
+    occurrences = tuple(occurence for occurence in Occurrences(client))
     assert client.get.call_count == 2
-    assert len(occurences) == 4
+    assert len(occurrences) == 4

--- a/Python/crossfire/tests/test_occurences.py
+++ b/Python/crossfire/tests/test_occurences.py
@@ -4,29 +4,24 @@ from crossfire.occurrences import Occurrences
 
 
 def dummy_response(last_page=False):
-    return {
-        "pageMeta": {
-            "hasNextPage": not last_page,
+    return [
+        {
+            "id": "a7bfebed-ce9c-469d-a656-924ed8248e95",
+            "latitude": "-8.1576367000",
+            "longitude": "-34.9696372000",
         },
-        "data": [
-            {
-                "id": "a7bfebed-ce9c-469d-a656-924ed8248e95",
-                "latitude": "-8.1576367000",
-                "longitude": "-34.9696372000",
-            },
-            {
-                "id": "a14d18dd-b28f-4c30-af07-5fa40d88b3f7",
-                "latitude": "-7.9800434000",
-                "longitude": "-35.0553350000",
-            },
-        ],
-    }
+        {
+            "id": "a14d18dd-b28f-4c30-af07-5fa40d88b3f7",
+            "latitude": "-7.9800434000",
+            "longitude": "-35.0553350000",
+        },
+    ], last_page
 
 
 def test_occurrences_from_at_least_two_pages():
     client = Mock()
-    client.get.return_value.json.return_value = dummy_response()
-    generator = Occurrences(client, id_state="42", id_cities=21, format="df")
+    client.get.return_value = dummy_response()
+    generator = Occurrences(client, id_state="42")
     occurrences = tuple(occ for count, occ in enumerate(generator, 1) if count <= 3)
     assert client.get.call_count == 2
     assert len(occurrences) == 3
@@ -34,13 +29,15 @@ def test_occurrences_from_at_least_two_pages():
 
 def test_occurrences_stops_when_there_are_no_more_pages():
     client = Mock()
-    client.get.return_value.json.side_effect = (
+    client.get.return_value = (
         dummy_response(False),
         dummy_response(True),
     )
-    occurrences = tuple(
-        occurence
-        for occurence in Occurrences(client, id_state="42", id_cities=21, format="df")
-    )
+    occurrences = tuple(occurence for occurence in Occurrences(client, id_state="42"))
     assert client.get.call_count == 2
     assert len(occurrences) == 4
+
+
+# TODO conto confirmar url com idState
+# TODO criar testes específicos para cada parametro de Ocurrence
+# TODO dummy_response: client.get.return_value = dummy_response()

--- a/Python/crossfire/tests/test_occurences.py
+++ b/Python/crossfire/tests/test_occurences.py
@@ -61,3 +61,16 @@ def test_occurrences_with_obligtory_and_id_cities_parameters():
     client.get.assert_called_once_with(
         f"{client.URL}/occurrences?idState=42&idCities=21&page=1"
     )
+
+
+def test_occurrences_with_obligtory_and_two_id_cities_parameters():
+    client = Mock()
+    client.get.return_value = dummy_response(True)
+    client.URL = "https://api-service.fogocruzado.org.br/api/v2/"
+    tuple(
+        occurence
+        for occurence in Occurrences(client, id_state="42", id_cities=["21", "11"])
+    )
+    client.get.assert_called_once_with(
+        f"{client.URL}/occurrences?idState=42&idCities=21&idCities=11&page=1"
+    )

--- a/Python/crossfire/tests/test_occurences.py
+++ b/Python/crossfire/tests/test_occurences.py
@@ -22,14 +22,21 @@ def test_occurrences_from_at_least_two_pages():
     client = Mock()
     client.get.return_value = dummy_response()
     generator = Occurrences(client, id_state="42")
-    occurrences = tuple(occ for count, occ in enumerate(generator, 1) if count <= 3)
+    lista = []
+    for count, occ in enumerate(generator, 1):
+        if count <= 3:
+            lista.append(occ)
+        else:
+            break
+    occurrences = tuple(lista)
+
     assert client.get.call_count == 2
     assert len(occurrences) == 3
 
 
 def test_occurrences_stops_when_there_are_no_more_pages():
     client = Mock()
-    client.get.return_value.side_effect = (
+    client.get.side_effect = (
         dummy_response(False),
         dummy_response(True),
     )

--- a/Python/crossfire/tests/test_occurences.py
+++ b/Python/crossfire/tests/test_occurences.py
@@ -43,3 +43,21 @@ def test_occurrences_stops_when_there_are_no_more_pages():
     occurrences = tuple(occurence for occurence in Occurrences(client, id_state="42"))
     assert client.get.call_count == 2
     assert len(occurrences) == 4
+
+
+def test_occurrences_with_obligtory_parameters():
+    client = Mock()
+    client.get.return_value = dummy_response(True)
+    client.URL = "https://api-service.fogocruzado.org.br/api/v2/"
+    tuple(occurence for occurence in Occurrences(client, id_state="42"))
+    client.get.assert_called_once_with(f"{client.URL}/occurrences?idState=42&page=1")
+
+
+def test_occurrences_with_obligtory_and_id_cities_parameters():
+    client = Mock()
+    client.get.return_value = dummy_response(True)
+    client.URL = "https://api-service.fogocruzado.org.br/api/v2/"
+    tuple(occurence for occurence in Occurrences(client, id_state="42", id_cities="21"))
+    client.get.assert_called_once_with(
+        f"{client.URL}/occurrences?idState=42&idCities=21&page=1"
+    )

--- a/Python/crossfire/tests/test_occurences.py
+++ b/Python/crossfire/tests/test_occurences.py
@@ -15,7 +15,7 @@ def dummy_response(last_page=False):
             "latitude": "-7.9800434000",
             "longitude": "-35.0553350000",
         },
-    ], last_page
+    ], not last_page
 
 
 def test_occurrences_from_at_least_two_pages():
@@ -29,7 +29,7 @@ def test_occurrences_from_at_least_two_pages():
 
 def test_occurrences_stops_when_there_are_no_more_pages():
     client = Mock()
-    client.get.return_value = (
+    client.get.return_value.side_effect = (
         dummy_response(False),
         dummy_response(True),
     )

--- a/Python/crossfire/tests/test_occurences.py
+++ b/Python/crossfire/tests/test_occurences.py
@@ -26,7 +26,7 @@ def dummy_response(last_page=False):
 def test_occurrences_from_at_least_two_pages():
     client = Mock()
     client.get.return_value.json.return_value = dummy_response()
-    generator = Occurrences(client)
+    generator = Occurrences(client, id_state="42", id_cities=21, format="df")
     occurrences = tuple(occ for count, occ in enumerate(generator, 1) if count <= 3)
     assert client.get.call_count == 2
     assert len(occurrences) == 3
@@ -38,6 +38,9 @@ def test_occurrences_stops_when_there_are_no_more_pages():
         dummy_response(False),
         dummy_response(True),
     )
-    occurrences = tuple(occurence for occurence in Occurrences(client))
+    occurrences = tuple(
+        occurence
+        for occurence in Occurrences(client, id_state="42", id_cities=21, format="df")
+    )
     assert client.get.call_count == 2
     assert len(occurrences) == 4

--- a/Python/crossfire/tests/test_occurences.py
+++ b/Python/crossfire/tests/test_occurences.py
@@ -36,8 +36,3 @@ def test_occurrences_stops_when_there_are_no_more_pages():
     occurrences = tuple(occurence for occurence in Occurrences(client, id_state="42"))
     assert client.get.call_count == 2
     assert len(occurrences) == 4
-
-
-# TODO conto confirmar url com idState
-# TODO criar testes específicos para cada parametro de Ocurrence
-# TODO dummy_response: client.get.return_value = dummy_response()


### PR DESCRIPTION
Depende do #31 e fecha #38, caso aprovado.
O endpoint `Occurrences` permite a requisição de mais de uma cidade (`id_cities`) para um mesmo estado.
Com isso temos a seguinte possibilidade para Occurrences:
a) O parâmetro `id-state` é obrigatório, 
    1. o parâmetro `id_cities` pode ser `None`, com isso retornando dados para todo o estado;
    2. o parâmetro `id_cities` pode ser uma única id, retornando dados de uma cidade de um estado em específico ou;
    3. o parâmetro `id_cities` pode ser uma lista de ids, retornando dados de mais de uma cidade de um estado;

Para poder permitir isso, proponho alterar a forma como estavamos criando a url a ser requisitada.
A proposta é que agora ela seja criada em formato de lista de tuplas.
Começando no `init` com a informação obrigatória de `id_state` e,  caso o `id_citites` seja uma lista, é retornado uma lista de tuplas `[("id_state", id_state), ("chave", valor1"), ("chave", valor2)]`. Caso `id_cities` seja um valor único, `[("id_state", id_state), ("chave", "valor1")]`.
Com isso temos a criação do `self.params` e em seguida a criação do `self.urlbase` já incluindo o `self.client.url`:
`self.urlbase = f"{self.client.URL}/occurrences?{urlencode(self.params)}"`

Essa abordagem não segue a anterior que estava basada em dicionário pois dicionários não permitem a repetição de chaves, o que seria necessário ao termos lista de `id_cities`;

Ao final, em `load_occurrences` o parẫmetro `page` é adicionado à url final a ser requisitada.

O que você acha?