### PR TITLE
Adiciona opção de limite para consulta de ocorrências

### DIFF
--- a/Python/crossfire/crossfire/occurrences.py
+++ b/Python/crossfire/crossfire/occurrences.py
@@ -3,12 +3,14 @@ from urllib.parse import urlencode
 
 
 class Occurrences:
-    def __init__(self, client, id_state, id_cities=None, format=None):
+    def __init__(self, client, id_state, id_cities=None, limit=None, format=None):
         self.client = client
         self.format = format
+        self.limit = limit
 
         self.buffer = Queue()
         self.next_page = 1
+        self.yielded = 0
 
         self.params = {
             key: value
@@ -20,6 +22,9 @@ class Occurrences:
         return self
 
     def __next__(self):
+        if self.limit and self.yielded >= self.limit:
+            raise StopIteration
+
         if self.buffer.empty():
             if not self.next_page:
                 raise StopIteration
@@ -30,6 +35,7 @@ class Occurrences:
         except Empty:
             raise StopIteration
 
+        self.yielded += 1
         return occurrence
 
     def load_occurrences(self):

--- a/Python/crossfire/tests/test_occurences.py
+++ b/Python/crossfire/tests/test_occurences.py
@@ -21,14 +21,7 @@ def dummy_response(last_page=False):
 def test_occurrences_from_at_least_two_pages():
     client = Mock()
     client.get.return_value = dummy_response()
-    generator = Occurrences(client, id_state="42")
-    lista = []
-    for count, occ in enumerate(generator, 1):
-        if count <= 3:
-            lista.append(occ)
-        else:
-            break
-    occurrences = tuple(lista)
+    occurrences = tuple(Occurrences(client, id_state="42", limit=3))
 
     assert client.get.call_count == 2
     assert len(occurrences) == 3
@@ -45,19 +38,26 @@ def test_occurrences_stops_when_there_are_no_more_pages():
     assert len(occurrences) == 4
 
 
+def test_occurances_with_limit():
+    client = Mock()
+    client.get.return_value = dummy_response()
+    occurences = tuple(Occurrences(client, id_state="42", limit=42))
+    assert len(occurences) == 42
+
+
 def test_occurrences_with_obligtory_parameters():
     client = Mock()
-    client.get.return_value = dummy_response(True)
+    client.get.return_value = dummy_response()
     client.URL = "https://127.0.0.1/"
-    tuple(occurence for occurence in Occurrences(client, id_state="42"))
+    tuple(Occurrences(client, id_state="42", limit=1))
     client.get.assert_called_once_with(f"{client.URL}/occurrences?idState=42&page=1")
 
 
 def test_occurrences_with_obligtory_and_id_cities_parameters():
     client = Mock()
-    client.get.return_value = dummy_response(True)
+    client.get.return_value = dummy_response()
     client.URL = "https://127.0.0.1/"
-    tuple(occurence for occurence in Occurrences(client, id_state="42", id_cities="21"))
+    tuple(Occurrences(client, id_state="42", id_cities="21", limit=2))
     client.get.assert_called_once_with(
         f"{client.URL}/occurrences?idState=42&idCities=21&page=1"
     )


### PR DESCRIPTION
Isso facilita o uso, evitando a necessidade de `break` quando não queremos todos os registros — por exemplo, ao invés de:

```python
ocorências = []
for occorência in Occurences(id_state=42):
    ocorrências.append(ocorrência)
    if len(ocorrências) == 100:
        break
```

Podemos ter apenas:

```python
ocorrências = tuple(Occurences(id_state=42, limit=100))
```