### PR TITLE
Simplifica lógica de criação dos parâmetros na classe de ocorrências

### DIFF
--- a/Python/crossfire/crossfire/occurrences.py
+++ b/Python/crossfire/crossfire/occurrences.py
@@ -10,11 +10,9 @@ class Occurrences:
         self.buffer = Queue()
         self.next_page = 1
 
-        self.params = {
-            key: value
-            for key, value in {"idState": id_state, "idCities": id_cities}.items()
-            if value
-        }
+        self.params = {"idState": id_state}
+        if id_cities:
+            self.params["idCities"] = id_cities
 
     def __iter__(self):
         return self


### PR DESCRIPTION
Esse código, na minha opinião, é muito mais complexo do que precisamos:

```python
self.params = {
    key: value
    for key, value in {"idState": id_state, "idCities": id_cities}.items()
    if value
}
```

Na sequência:
* Criamos um dicionário com `idStates` e `idCities`
* Iteramos nesse dicionário transformando cada par em uma tupla
* Comparamos se cada valor é `None` (ou `not False`) ou não
* Criamos um novo dicionário


Dado que, `id_state` é um argumento obrigatório na classe e nunca vai ser `None`, tudo que essa lógica está fazendo é garantindo que só adicionamos `id_city` se não for `None`. Isso pode ser feito com um simples `if`:

```python
    self.params = {"idState": id_state}
    if id_city:
        # add it to the dict
```