### PR TITLE
Expõe todas as metainformações de uma consulta à API

### DIFF
--- a/Python/crossfire/crossfire/occurrences.py
+++ b/Python/crossfire/crossfire/occurrences.py
@@ -41,14 +41,14 @@ class Occurrences:
             return
 
         self.params["page"] = self.next_page
-        occurrences, has_next_page = self.client.get(
+        occurrences, metadata = self.client.get(
             f"{self.client.URL}/occurrences?{urlencode(self.params)}"
         )
 
         for occurrence in occurrences:
             self.buffer.put(occurrence)
 
-        if has_next_page:
+        if metadata.has_next_page:
             self.next_page += 1
         else:
             self.next_page = None

--- a/Python/crossfire/tests/test_occurences.py
+++ b/Python/crossfire/tests/test_occurences.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock
 
 from crossfire.occurrences import Occurrences
+from crossfire.parser import Metadata
 
 
 def dummy_response(last_page=False):
@@ -15,7 +16,7 @@ def dummy_response(last_page=False):
             "latitude": "-7.9800434000",
             "longitude": "-35.0553350000",
         },
-    ], not last_page
+    ], Metadata.from_response({"pageMeta": {"hasNextPage": not last_page}})
 
 
 def test_occurrences_from_at_least_two_pages():

--- a/Python/crossfire/tests/test_parser.py
+++ b/Python/crossfire/tests/test_parser.py
@@ -39,14 +39,14 @@ def test_parse_response_uses_dict_by_default():
     assert isinstance(data, list)
 
 
-def test_parse_response_handles_has_next_page():
+def test_parse_response_handles_metadata():
     paginated = DummyClient(has_next_page=True)
-    _, has_next_page = paginated.get()
-    assert has_next_page
+    _, metadata = paginated.get()
+    assert metadata.has_next_page
 
     not_paginated = DummyClient()
-    _, has_next_page = not_paginated.get()
-    assert not has_next_page
+    _, metadata = not_paginated.get()
+    assert not metadata.has_next_page
 
 
 def test_parse_response_uses_dataframe_when_specified():


### PR DESCRIPTION
Parte da #46

Para podermos fazer mais reequisições em paralelo, precisamos saber quantas páginas temos que requisitar. Esse PR facilita isso expondo outros dados do `pageMeta` além do `hasNextPage`.

