### PR TITLE
Bug fix: Torna `python-decouple` dependência do projeto

### DIFF
--- a/Python/crossfire/poetry.lock
+++ b/Python/crossfire/poetry.lock
@@ -922,4 +922,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "a9b06da7eb2df60c790ac849c4399282a3d6a314505fff30bee617832710d91c"
+content-hash = "54242e001161017775963ec9725ec258dfdc2f5fbc95e39bbd1e664861313cea"

--- a/Python/crossfire/pyproject.toml
+++ b/Python/crossfire/pyproject.toml
@@ -19,12 +19,10 @@ exclude =  ["man/", "R/", "tables/", "crossfire.Rproj", "DESCRIPTION", "env-exam
 
 [tool.poetry.dependencies]
 python = "^3.9"
-requests = "^2.26.0"
-pandas = "^2.1.0"
 geopandas = "^0.13.2"
-
-[tool.poetry.dev-dependencies]
+pandas = "^2.1.0"
 python-decouple = "^3.5"
+requests = "^2.26.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.2"


### PR DESCRIPTION
Atualmente o `python-decouple` está no grupo (legado) de dependências de desenvolvimento. Isso é um erro, dado que utilizamos a dependência no fluxo normal do `Client` — ou seja, não apenas em desenvolvimento. O _bug_ seria que ao instalar o pacote via `pip` teríamos um erro na importação desse pacote ao iniciar um cliente.

Esse PR move a dependência para o grupo “dependências” (não apenas “dependências de desenvolvimento”).

