### PR TITLE
Adiciona configuração para limitar número de requisicões paralelas

### DIFF
--- a/Python/crossfire/crossfire/client.py
+++ b/Python/crossfire/crossfire/client.py
@@ -29,21 +29,20 @@ class Token:
 
 class Client:
     URL = "https://api-service.fogocruzado.org.br/api/v2"
+    MAX_PARALLEL_REQUESTS = 32
 
-    def __init__(self, **kwargs):
-        self.email = kwargs.get("email")
-        self.password = kwargs.get("password")
-        if self.email is None:
-            try:
-                self.email = config("FOGOCRUZADO_EMAIL")
-            except UndefinedValueError:
-                raise CredentialsNotFoundError("FOGOCRUZADO_EMAIL")
-        if self.password is None:
-            try:
-                self.password = kwargs.get("password", config("FOGOCRUZADO_PASSWORD"))
-            except UndefinedValueError:
-                raise CredentialsNotFoundError("FOGOCRUZADO_PASSWORD")
+    def __init__(self, email=None, password=None, max_parallel_requests=None):
+        try:
+            self.email = email or config("FOGOCRUZADO_EMAIL")
+        except UndefinedValueError:
+            raise CredentialsNotFoundError("FOGOCRUZADO_EMAIL")
 
+        try:
+            self.password = password or config("FOGOCRUZADO_PASSWORD")
+        except UndefinedValueError:
+            raise CredentialsNotFoundError("FOGOCRUZADO_PASSWORD")
+
+        self.max_parallel_requests = max_parallel_requests or self.MAX_PARALLEL_REQUESTS
         self.cached_token = None
 
     @property

--- a/Python/crossfire/tests/test_client.py
+++ b/Python/crossfire/tests/test_client.py
@@ -55,6 +55,18 @@ def test_client_initiates_with_credentials_from_kwargs():
     assert client.password == "password.kwargs"
 
 
+def test_client_initiates_with_default_max_parallel_requests_setting():
+    with patch("crossfire.client.config"):
+        client = Client()
+        client.max_parallel_requests == Client.MAX_PARALLEL_REQUESTS
+
+
+def test_client_initiates_with_custom_max_parallel_requests_setting():
+    with patch("crossfire.client.config"):
+        client = Client(max_parallel_requests=42)
+        client.max_parallel_requests == 42
+
+
 def test_client_returns_a_token_when_cached_token_is_valid(client_with_token):
     assert client_with_token.token == "42"
 


### PR DESCRIPTION
Parte de #46 

Esse limite ainda não é utilizado, mas é parte integrante da melhoria de performance mencionada na _issue_. Pode ser inderido depois, mas creio que PRs menores facilitem a revisão.