### PR TITLE
add type_occurrence parameter on Occurrence

### DIFF
--- a/Python/crossfire/crossfire/occurrences.py
+++ b/Python/crossfire/crossfire/occurrences.py
@@ -1,18 +1,39 @@
 from queue import Empty, Queue
 from urllib.parse import urlencode
 
+from crossfire.errors import CrossfireError
+
+TYPE_OCCURRENCES = {"all", "withVictim", "withoutVictim"}
+
+
+class UnknownTypeOccurrenceError(CrossfireError):
+    def __init__(self, type_occurrence):
+        message = ("""Unknown type_occurrence""",)
+        f"`{type_occurrence}`. Valid formats are: {', '.join(TYPE_OCCURRENCES)}"
+        super().__init__(message)
+
 
 class Occurrences:
-    def __init__(self, client, id_state, id_cities=None, limit=None, format=None):
+    def __init__(
+        self,
+        client,
+        id_state,
+        id_cities=None,
+        limit=None,
+        format=None,
+        type_occurrence="all",
+    ):
         self.client = client
         self.format = format
         self.limit = limit
+        if type_occurrence and type_occurrence not in TYPE_OCCURRENCES:
+            raise UnknownTypeOccurrenceError(type_occurrence)
 
         self.buffer = Queue()
         self.next_page = 1
         self.yielded = 0
 
-        self.params = {"idState": id_state}
+        self.params = {"idState": id_state, "typeOccurrence": type_occurrence}
         if id_cities:
             self.params["idCities"] = id_cities
 

--- a/Python/crossfire/crossfire/occurrences.py
+++ b/Python/crossfire/crossfire/occurrences.py
@@ -8,8 +8,10 @@ TYPE_OCCURRENCES = {"all", "withVictim", "withoutVictim"}
 
 class UnknownTypeOccurrenceError(CrossfireError):
     def __init__(self, type_occurrence):
-        message = ("""Unknown type_occurrence""",)
-        f"`{type_occurrence}`. Valid formats are: {', '.join(TYPE_OCCURRENCES)}"
+        message = (
+            f"Unknown type_occurrence `{type_occurrence}`. "
+            f"Valid formats are: {', '.join(TYPE_OCCURRENCES)}"
+        )
         super().__init__(message)
 
 

--- a/Python/crossfire/crossfire/occurrences.py
+++ b/Python/crossfire/crossfire/occurrences.py
@@ -28,7 +28,7 @@ class Occurrences:
         self.client = client
         self.format = format
         self.limit = limit
-        if type_occurrence and type_occurrence not in TYPE_OCCURRENCES:
+        if type_occurrence not in TYPE_OCCURRENCES:
             raise UnknownTypeOccurrenceError(type_occurrence)
 
         self.buffer = Queue()

--- a/Python/crossfire/tests/test_occurences.py
+++ b/Python/crossfire/tests/test_occurences.py
@@ -110,3 +110,27 @@ def test_occurrence_url_with_two_cities():
 def test_occurrence_raises_error_for_unkown_type_occurrence_parameter():
     with raises(UnknownTypeOccurrenceError):
         Occurrences(None, id_state="42", limit=1, type_occurrence="42")
+
+
+def test_occurrences_with_victims():
+    client = Mock()
+    client.URL = "https://127.0.0.1"
+    occurence_with_victims = Occurrences(
+        client, id_state=42, type_occurrence="withVictim"
+    )
+    assert (
+        occurence_with_victims.url
+        == "https://127.0.0.1/occurrences?idState=42&typeOccurrence=withVictim"
+    )
+
+
+def test_occurrences_without_victims():
+    client = Mock()
+    client.URL = "https://127.0.0.1"
+    occurence_without_victims = Occurrences(
+        client, id_state=42, type_occurrence="withoutVictim"
+    )
+    assert (
+        occurence_without_victims.url
+        == "https://127.0.0.1/occurrences?idState=42&typeOccurrence=withoutVictim"
+    )

--- a/Python/crossfire/tests/test_occurences.py
+++ b/Python/crossfire/tests/test_occurences.py
@@ -1,6 +1,8 @@
 from unittest.mock import Mock
 
-from crossfire.occurrences import Occurrences
+from pytest import raises
+
+from crossfire.occurrences import Occurrences, UnknownTypeOccurrenceError
 from crossfire.parser import Metadata
 
 
@@ -51,7 +53,9 @@ def test_occurrences_with_obligtory_parameters():
     client.get.return_value = dummy_response()
     client.URL = "https://127.0.0.1/"
     tuple(Occurrences(client, id_state="42", limit=1))
-    client.get.assert_called_once_with(f"{client.URL}/occurrences?idState=42&page=1")
+    client.get.assert_called_once_with(
+        f"{client.URL}/occurrences?idState=42&typeOccurrence=all&page=1"
+    )
 
 
 def test_occurrences_with_obligtory_and_id_cities_parameters():
@@ -60,7 +64,7 @@ def test_occurrences_with_obligtory_and_id_cities_parameters():
     client.URL = "https://127.0.0.1/"
     tuple(Occurrences(client, id_state="42", id_cities="21", limit=1))
     client.get.assert_called_once_with(
-        f"{client.URL}/occurrences?idState=42&idCities=21&page=1"
+        f"{client.URL}/occurrences?idState=42&typeOccurrence=all&idCities=21&page=1"
     )
 
 
@@ -70,7 +74,7 @@ def test_occurrences_with_obligtory_and_two_id_cities_parameters():
     client.URL = "https://127.0.0.1/"
     tuple(Occurrences(client, id_state="42", id_cities=["21", "11"], limit=1))
     client.get.assert_called_once_with(
-        f"{client.URL}/occurrences?idState=42&idCities=21&idCities=11&page=1"
+        f"{client.URL}/occurrences?idState=42&typeOccurrence=all&idCities=21&idCities=11&page=1"
     )
 
 
@@ -78,7 +82,9 @@ def test_occurrence_url_with_only_mandatory_params():
     client = Mock()
     client.URL = "https://127.0.0.1"
     occurence = Occurrences(client, id_state=42)
-    assert occurence.url == "https://127.0.0.1/occurrences?idState=42"
+    assert (
+        occurence.url == "https://127.0.0.1/occurrences?idState=42&typeOccurrence=all"
+    )
 
 
 def test_occurrence_url_with_one_city():
@@ -86,7 +92,8 @@ def test_occurrence_url_with_one_city():
     client.URL = "https://127.0.0.1"
     occurence = Occurrences(client, id_state=42, id_cities="fourty-two")
     assert (
-        occurence.url == "https://127.0.0.1/occurrences?idState=42&idCities=fourty-two"
+        occurence.url
+        == "https://127.0.0.1/occurrences?idState=42&typeOccurrence=all&idCities=fourty-two"
     )
 
 
@@ -96,5 +103,10 @@ def test_occurrence_url_with_two_cities():
     occurence = Occurrences(client, id_state=42, id_cities=["fourty-two", 42])
     assert (
         occurence.url
-        == "https://127.0.0.1/occurrences?idState=42&idCities=fourty-two&idCities=42"
+        == "https://127.0.0.1/occurrences?idState=42&typeOccurrence=all&idCities=fourty-two&idCities=42"
     )
+
+
+def test_occurrence_raises_error_for_unkown_type_occurrence_parameter():
+    with raises(UnknownTypeOccurrenceError):
+        Occurrences(None, id_state="42", limit=1, type_occurrence="42")


### PR DESCRIPTION
Este PR adiciona o parâmetro `type_occurrence` à classe `Occurrence`. Por padrão, o valor é `all`. Como sugerido em #39 (de tomar como exemplo o `format`), criei uma contacte com os valores possíveis. O init de Occurrences, valido se o `type_occurrence` está listado na constante. Caso contrário, levanta um `TypeOccurrenceError` e, na mensagem informamos quais seriam os valores possíveis.

Com isso alguns testes relacionado a `OCcurrence tiveram que ser atualizados. E foi criado um teste para validar o erro quando o parâmetro informado não for contemplado na constante...