### PR TITLE
Corrige erro no _loop_ utilizado pelo `asyncio`

### DIFF
--- a/Python/crossfire/crossfire/client.py
+++ b/Python/crossfire/crossfire/client.py
@@ -1,4 +1,4 @@
-from asyncio import run
+from asyncio import get_event_loop
 from datetime import datetime, timedelta
 from urllib.parse import urlencode
 
@@ -88,7 +88,8 @@ class Client:
         return await self.get(f"{self.URL}/states", format=format)
 
     def states(self, *args, **kwargs):
-        states, _ = run(self._states(*args, **kwargs))
+        loop = get_event_loop()
+        states, _ = loop.run_until_complete(self._states(*args, **kwargs))
         return states
 
     async def _cities(self, city_id=None, city_name=None, state_id=None, format=None):
@@ -97,5 +98,6 @@ class Client:
         return await self.get(f"{self.URL}/cities?{cleaned}", format=format)
 
     def cities(self, *args, **kwargs):
-        cities, _ = run(self._cities(*args, **kwargs))
+        loop = get_event_loop()
+        cities, _ = loop.run_until_complete(self._cities(*args, **kwargs))
         return cities


### PR DESCRIPTION
Existe um erro no código atual que impede chmarmos duas vezes uma função que utiliza o cliente `asyncio`.

```python
from crossfire.client import Client


client = Client()
client.states()  # essa funcionaria
client.states()  # essa falharia
```

Isso porquê o `async.run` encerra o _loop_. Então esse PR sugere substituir o `async.run` pela combinação
* pegar o _event loop_ atual
* executar a corotina nesse _event loop_