### PR TITLE
Gera erro para status HTTP 429 Too Many Requests

### DIFF
--- a/Python/crossfire/tests/test_parser.py
+++ b/Python/crossfire/tests/test_parser.py
@@ -2,16 +2,24 @@ from geopandas import GeoDataFrame
 from pandas import DataFrame
 from pytest import mark, raises
 
-from crossfire.parser import IncompatibleDataError, UnknownFormatError, parse_response
+from crossfire.parser import (
+    IncompatibleDataError,
+    RetryAfterError,
+    UnknownFormatError,
+    parse_response,
+)
 
 
 class DummyResponse:
     DATA = [{"answer": 42}]
     GEODATA = [{"answer": 42, "latitude_ocorrencia": 4, "longitude_ocorrencia": 2}]
 
-    def __init__(self, geo, has_next_page):
+    def __init__(self, geo, has_next_page, status_code):
         self.geo = geo
         self.has_next_page = has_next_page
+        self.status_code = status_code
+        if status_code == 429:
+            self.headers = {"retry-after": 42}
 
     def json(self):
         data = self.GEODATA if self.geo else self.DATA
@@ -19,8 +27,10 @@ class DummyResponse:
 
 
 class DummyClient:
-    def __init__(self, geo=False, has_next_page=False):
-        self.response = DummyResponse(geo=geo, has_next_page=has_next_page)
+    def __init__(self, geo=False, has_next_page=False, status_code=200):
+        self.response = DummyResponse(
+            geo=geo, has_next_page=has_next_page, status_code=status_code
+        )
 
     @parse_response
     async def get(self, *args, **kwargs):
@@ -73,3 +83,10 @@ async def test_parse_response_raises_error_when_missing_coordinates():
     client = DummyClient()
     with raises(IncompatibleDataError):
         await client.get(geo=True, format="geodf")
+
+
+@mark.asyncio
+async def test_parse_response_raises_error_for_too_many_requests():
+    client = DummyClient(status_code=429)
+    with raises(RetryAfterError):
+        await client.get()


### PR DESCRIPTION
Depende do #58 

Quando a API retorna HTTP Status 429 (TOO Many Requests), capturamos esse status e geramos um erro específico. Isso vai permitir uma espera e tentar novamente a mesma requisição no futuro.