### PR TITLE
Cria um “acumulador” para salvar os resultados de diversar requisições

### DIFF
--- a/Python/crossfire/crossfire/occurrences.py
+++ b/Python/crossfire/crossfire/occurrences.py
@@ -2,6 +2,16 @@ from asyncio import run
 from queue import Empty, Queue
 from urllib.parse import urlencode
 
+try:
+    from pandas import concat
+except ImportError:
+    pass
+
+try:
+    from geopandas import GeoDataFrame
+except ImportError:
+    pass
+
 
 class Occurrences:
     def __init__(self, client, id_state, id_cities=None, limit=None, format=None):
@@ -56,3 +66,34 @@ class Occurrences:
             self.next_page += 1
         else:
             self.next_page = None
+
+
+class Accumulator:
+    def __init__(self):
+        self.data = None
+        self.is_gdf = False
+
+    def save(self, *pages):
+        self.data, *remaining = pages
+        if isinstance(self.data, GeoDataFrame):
+            self.is_gdf = True
+        return self if not remaining else self.merge(remaining)
+
+    def merge(self, *pages):
+        if self.data is None:
+            return self.save(*pages)
+
+        if isinstance(self.data, list):
+            for page in pages:
+                self.data.extend(page)
+            return self
+
+        dfs = [self.data] + list(pages)
+        self.data = concat(dfs, ignore_index=True)
+        return self
+
+    def __call__(self):
+        if self.is_gdf:
+            return GeoDataFrame(self.data)
+
+        return self.data

--- a/Python/crossfire/tests/test_occurences.py
+++ b/Python/crossfire/tests/test_occurences.py
@@ -1,6 +1,10 @@
 from unittest.mock import AsyncMock, Mock
 
-from crossfire.occurrences import Occurrences
+from geopandas import GeoDataFrame
+from pandas import DataFrame
+from pandas.testing import assert_frame_equal
+
+from crossfire.occurrences import Accumulator, Occurrences
 from crossfire.parser import Metadata
 
 
@@ -17,6 +21,27 @@ def dummy_response(last_page=False):
             "longitude": "-35.0553350000",
         },
     ], Metadata.from_response({"pageMeta": {"hasNextPage": not last_page}})
+
+
+def test_occurrences_accumulator_for_lists():
+    accumulator = Accumulator()
+    accumulator.merge([1])
+    accumulator.merge([2], [3])
+    assert accumulator() == [1, 2, 3]
+
+
+def test_occurrences_accumulator_for_df():
+    accumulator = Accumulator()
+    accumulator.merge(DataFrame([{"a": 1}]))
+    accumulator.merge(DataFrame([{"a": 2}]), DataFrame([{"a": 3}]))
+    assert_frame_equal(accumulator(), DataFrame([{"a": 1}, {"a": 2}, {"a": 3}]))
+
+
+def test_occurrences_accumulator_for_geodf():
+    accumulator = Accumulator()
+    accumulator.merge(GeoDataFrame([{"a": 1}]))
+    accumulator.merge(GeoDataFrame([{"a": 2}]), GeoDataFrame([{"a": 3}]))
+    assert_frame_equal(accumulator(), GeoDataFrame([{"a": 1}, {"a": 2}, {"a": 3}]))
 
 
 def test_occurrences_from_at_least_two_pages():


### PR DESCRIPTION
Esse PR cria um acumulador para guardar todas as ocorrências (não importando se são uma lista de dicionáro, ou um _dataframe_ do Pandas ou GeoPandas). Como exemplo, dos testes:

```python
accumulator = Accumulator()
accumulator.merge([1])
accumulator.merge([2], [3])
accumulator()  # [1, 2, 3]
```

E funciona igual com `DataFrame` e `GeoDataTrame`:

```python
accumulator = Accumulator()
accumulator.merge(DataFrame([{"a": 1}]))
accumulator.merge(DataFrame([{"a": 2}]), DataFrame([{"a": 3}]))
```

```python
accumulator = Accumulator()
accumulator.merge(GeoDataFrame([{"a": 1}]))
accumulator.merge(GeoDataFrame([{"a": 2}]), GeoDataFrame([{"a": 3}]))
```

Esse `Accumulator` será utilizado para agregar os resultados de diversas requições (uma para cada página) com o cliente `async`.