### PR TITLE
Remove o limite de conexões paralelas

### DIFF
--- a/Python/crossfire/crossfire/client.py
+++ b/Python/crossfire/crossfire/client.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from urllib.parse import urlencode
 
 from decouple import UndefinedValueError, config
-from httpx import AsyncClient, Limits
+from httpx import AsyncClient
 
 from crossfire.errors import CrossfireError
 from crossfire.parser import parse_response
@@ -30,7 +30,6 @@ class Token:
 
 class Client:
     URL = "https://api-service.fogocruzado.org.br/api/v2"
-    MAX_PARALLEL_REQUESTS = 32
 
     def __init__(self, email=None, password=None, max_parallel_requests=None):
         try:
@@ -43,10 +42,7 @@ class Client:
         except UndefinedValueError:
             raise CredentialsNotFoundError("FOGOCRUZADO_PASSWORD")
 
-        max_connections = max_parallel_requests or self.MAX_PARALLEL_REQUESTS
-        limits = Limits(max_connections=max_connections)
-
-        self.client = AsyncClient(default_encoding="utf-8", limits=limits)
+        self.client = AsyncClient(default_encoding="utf-8")
         self.credentials = {"email": email, "password": password}
         self.cached_token = None
 

--- a/Python/crossfire/tests/test_client.py
+++ b/Python/crossfire/tests/test_client.py
@@ -32,20 +32,6 @@ def test_client_initiates_with_credentials_from_kwargs():
     assert client.credentials["password"] == "password.kwargs"
 
 
-def test_client_initiates_with_default_max_parallel_requests_setting():
-    with patch("crossfire.client.config"), patch("crossfire.client.AsyncClient"):
-        with patch("crossfire.client.Limits") as limits:
-            Client()
-            limits.assert_called_once_with(max_connections=Client.MAX_PARALLEL_REQUESTS)
-
-
-def test_client_initiates_with_custom_max_parallel_requests_setting():
-    with patch("crossfire.client.config"), patch("crossfire.client.AsyncClient"):
-        with patch("crossfire.client.Limits") as limits:
-            Client(max_parallel_requests=42)
-            limits.assert_called_once_with(max_connections=42)
-
-
 @mark.asyncio
 async def test_client_returns_a_token_when_cached_token_is_valid(client_with_token):
     assert await client_with_token.token() == "42"


### PR DESCRIPTION
Vamos reimplementar em outro PR utilizando `asyncio.Sempahore`. Isso ajuda a manter a verificação SSL sem problemas de concorrência.