### PR TITLE
Refatora `parse_response`

### DIFF
--- a/Python/crossfire/crossfire/clients/occurrences.py
+++ b/Python/crossfire/crossfire/clients/occurrences.py
@@ -14,9 +14,8 @@ try:
 except ImportError:
     pass
 
-from crossfire.errors import CrossfireError
+from crossfire.errors import CrossfireError, RetryAfterError
 from crossfire.logger import Logger
-from crossfire.parser import RetryAfterError
 
 logger = Logger(__name__)
 

--- a/Python/crossfire/crossfire/errors.py
+++ b/Python/crossfire/crossfire/errors.py
@@ -1,2 +1,12 @@
 class CrossfireError(Exception):
     pass
+
+
+class RetryAfterError(CrossfireError):
+    def __init__(self, retry_after):
+        self.retry_after = retry_after
+        message = (
+            "Got HTTP Status 429 Too Many Requests. "
+            f"Retry after {self.retry_after} seconds"
+        )
+        super().__init__(message)

--- a/Python/crossfire/tests/test_client.py
+++ b/Python/crossfire/tests/test_client.py
@@ -8,6 +8,7 @@ from crossfire.clients import (
     Client,
     CredentialsNotFoundError,
     IncorrectCredentialsError,
+    RetryAfterError,
     Token,
 )
 from crossfire.parser import UnknownFormatError
@@ -100,6 +101,15 @@ async def test_client_inserts_auth_on_http_get_without_overwriting(client_and_ge
     mock.assert_called_once_with(
         "my-url", headers={"Authorization": "Bearer 42", "answer": "fourty-two"}
     )
+
+
+@mark.asyncio
+async def test_client_raises_error_for_too_many_requests(client_and_get_mock):
+    client, mock = client_and_get_mock
+    mock.return_value.status_code = 429
+    mock.return_value.headers = {"Retry-After": "42"}
+    with raises(RetryAfterError):
+        await client.get()
 
 
 def test_client_load_states(state_client_and_get_mock):


### PR DESCRIPTION
Remove a lógica de gerenciamento da requisição, movendo-a para o `Client`.

Closes #67