### PR TITLE
adiciona AsyncClient e Client em crossfire.__init__

### DIFF
--- a/crossfire/__init__.py
+++ b/crossfire/__init__.py
@@ -1,5 +1,5 @@
 __version__ = "0.1.0"
-__all__ = ("cities", "occurrences", "states")
+__all__ = ("AsyncClient", "Client", "cities", "occurrences", "states")
 
 from functools import lru_cache
 


### PR DESCRIPTION
Adiciona `AsyncClient` e `Client` ao `__all__` de `crossfire.__init__.py`, conforme proposta na issue #76 