### PR TITLE
aplica ruff format em clients.__init__

### DIFF
--- a/crossfire/clients/__init__.py
+++ b/crossfire/clients/__init__.py
@@ -117,7 +117,8 @@ class AsyncClient:
             id_state,
             id_cities=id_cities,
             type_occurrence=type_occurrence,
-            max_parallel_requests=max_parallel_requests or self.max_parallel_requests,
+            max_parallel_requests=max_parallel_requests
+            or self.max_parallel_requests,
             format=format,
         )
         return await occurrences()


### PR DESCRIPTION
@cuducos li a documentação e entendi como aplicar a formatação do ruff.
Ao fazer o merge, não prestei atenção que o seu PR não tinha (claro) os ultimos commits aceitos por PR.
Por isso abri uma branch nova para aplicar a formatação do ruff.

[agora, sim]