### PR TITLE
Corrige chamada do “tentar novamente” quando a requisição de uma ocorrência falha

### DIFF
--- a/crossfire/clients/occurrences.py
+++ b/crossfire/clients/occurrences.py
@@ -77,7 +77,7 @@ class Occurrences:
                 f"Too many requests. Waiting {wait}s before retrying page {number}"
             )
             await sleep(wait)
-            return await self.page(url)
+            return await self.page(number)
 
         if not self.total_pages:
             self.total_pages = metadata.page_count


### PR DESCRIPTION
[Como comentado](https://github.com/FelipeSBarros/crossfire/issues/85#issuecomment-1845541654):

> O cliente de ocorrências tem um método page(self, number) que, como o nome do argumento diz, espera um número de página para fazer a requisição.
>
> Acontece que quando a requisição falha, e vamos tentar novamente, estamos passando a URL para tentar novamente (ao invés do número da página para tentar novamente)