### PR TITLE
fixing Occurrences `format`parameter bug

### DIFF
--- a/crossfire/clients/occurrences.py
+++ b/crossfire/clients/occurrences.py
@@ -98,7 +98,9 @@ class Occurrences:
         failed = False
         async with self.semaphore:
             try:
-                occurrences, metadata = await self.client.get(url)
+                occurrences, metadata = await self.client.get(
+                    url, format=self.format
+                )
             except (ReadTimeout, RetryAfterError) as err:
                 failed = True
                 wait = getattr(err, "retry_after", 1)

--- a/tests/test_occurrences_client.py
+++ b/tests/test_occurrences_client.py
@@ -1,12 +1,10 @@
 import datetime
-from unittest.mock import patch
 
 from geopandas import GeoDataFrame
 from pandas import DataFrame
 from pandas.testing import assert_frame_equal
 from pytest import mark, raises
 
-from crossfire import AsyncClient, Client
 from crossfire.clients.occurrences import (
     Accumulator,
     Occurrences,
@@ -137,15 +135,20 @@ async def test_occurrences_without_victims(occurrences_client_and_get_mock):
 
 
 @mark.asyncio
-async def test_occurrences_with_format_parameter(occurrences_client_and_get_mock):
+async def test_occurrences_with_format_parameter(
+    occurrences_client_and_get_mock,
+):
     client, mock = occurrences_client_and_get_mock
-    occurrences = Occurrences(client, id_state=42, type_occurrence="withVictim")
+    occurrences = Occurrences(
+        client, id_state=42, type_occurrence="withVictim", format="df"
+    )
     await occurrences()
     mock.assert_called_once_with(
         "http://127.0.0.1/api/v2/occurrences?idState=42&typeOccurrence=withVictim&page=1",
         headers={"Authorization": "Bearer 42"},
-        format="None"
+        format="df",
     )
+
 
 def test_occurrence_raises_error_for_unknown_occurrence_type():
     with raises(UnknownTypeOccurrenceError):

--- a/tests/test_occurrences_client.py
+++ b/tests/test_occurrences_client.py
@@ -1,10 +1,12 @@
 import datetime
+from unittest.mock import patch
 
 from geopandas import GeoDataFrame
 from pandas import DataFrame
 from pandas.testing import assert_frame_equal
 from pytest import mark, raises
 
+from crossfire import AsyncClient, Client
 from crossfire.clients.occurrences import (
     Accumulator,
     Occurrences,
@@ -132,6 +134,26 @@ async def test_occurrences_without_victims(occurrences_client_and_get_mock):
         "http://127.0.0.1/api/v2/occurrences?idState=42&typeOccurrence=withoutVictim&page=1",
         headers={"Authorization": "Bearer 42"},
     )
+
+
+def test_client_load_occurrences():
+    with patch("crossfire.clients.config") as config_mock:
+        with patch.object(AsyncClient, "get") as async_get_mock:
+            config_mock.side_effect = ("email", "password")
+            client = Client()
+            Occurrences(
+                client,
+                id_state=42,
+                id_cities=42,
+                type_occurrence="all",
+                initial_date=None,
+                final_date=None,
+                max_parallel_requests=None,
+                format="None",
+            )
+            async_get_mock.assert_called_with(
+                format="None",
+            )
 
 
 def test_occurrence_raises_error_for_unknown_occurrence_type():

--- a/tests/test_occurrences_client.py
+++ b/tests/test_occurrences_client.py
@@ -1,5 +1,5 @@
 import datetime
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 from geopandas import GeoDataFrame
 from pandas import DataFrame
@@ -135,10 +135,14 @@ async def test_occurrences_without_victims(occurrences_client_and_get_mock):
     )
 
 
-def test_occurrences_with_format_parameter():
-    client_mock = Mock()
+@mark.asyncio
+async def test_occurrences_with_format_parameter():
+    client_mock = AsyncMock()
+    metadata_mock = Mock()
+    metadata_mock.json.return_value = {"pageMeta": {"pageCount": 1}}
+    client_mock.get.return_value = ("occs", metadata_mock)
     occurrences = Occurrences(client_mock, id_state=42, format="df")
-    occurrences()
+    await occurrences()
     occurrences.client.get.assert_called_once_with(
         "http://127.0.0.1/api/v2/occurrences?idState=42&typeOccurrence=withVictim&page=1",
         format="df",

--- a/tests/test_occurrences_client.py
+++ b/tests/test_occurrences_client.py
@@ -1,5 +1,5 @@
 import datetime
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock
 
 from geopandas import GeoDataFrame
 from pandas import DataFrame
@@ -13,6 +13,7 @@ from crossfire.clients.occurrences import (
     date_formatter,
 )
 from crossfire.errors import DateFormatError, DateIntervalError
+from crossfire.parser import Metadata
 
 
 def dummy_response(total_pages, last_page):
@@ -138,13 +139,20 @@ async def test_occurrences_without_victims(occurrences_client_and_get_mock):
 @mark.asyncio
 async def test_occurrences_with_format_parameter():
     client_mock = AsyncMock()
-    metadata_mock = Mock()
-    metadata_mock.json.return_value = {"pageMeta": {"pageCount": 1}}
-    client_mock.get.return_value = ("occs", metadata_mock)
+    metadata = Metadata(
+        page=1,
+        take=1,
+        item_count=1,
+        page_count=1,
+        has_previous_page=False,
+        has_next_page=False,
+    )
+    client_mock.get.return_value = ("occs", metadata)
+    client_mock.URL = "http://127.0.0.1/api/v2"
     occurrences = Occurrences(client_mock, id_state=42, format="df")
     await occurrences()
     occurrences.client.get.assert_called_once_with(
-        "http://127.0.0.1/api/v2/occurrences?idState=42&typeOccurrence=withVictim&page=1",
+        "http://127.0.0.1/api/v2/occurrences?idState=42&typeOccurrence=all&page=1",
         format="df",
     )
 

--- a/tests/test_occurrences_client.py
+++ b/tests/test_occurrences_client.py
@@ -136,25 +136,16 @@ async def test_occurrences_without_victims(occurrences_client_and_get_mock):
     )
 
 
-def test_client_load_occurrences():
-    with patch("crossfire.clients.config") as config_mock:
-        with patch.object(AsyncClient, "get") as async_get_mock:
-            config_mock.side_effect = ("email", "password")
-            client = Client()
-            Occurrences(
-                client,
-                id_state=42,
-                id_cities=42,
-                type_occurrence="all",
-                initial_date=None,
-                final_date=None,
-                max_parallel_requests=None,
-                format="None",
-            )
-            async_get_mock.assert_called_with(
-                format="None",
-            )
-
+@mark.asyncio
+async def test_occurrences_with_format_parameter(occurrences_client_and_get_mock):
+    client, mock = occurrences_client_and_get_mock
+    occurrences = Occurrences(client, id_state=42, type_occurrence="withVictim")
+    await occurrences()
+    mock.assert_called_once_with(
+        "http://127.0.0.1/api/v2/occurrences?idState=42&typeOccurrence=withVictim&page=1",
+        headers={"Authorization": "Bearer 42"},
+        format="None"
+    )
 
 def test_occurrence_raises_error_for_unknown_occurrence_type():
     with raises(UnknownTypeOccurrenceError):

--- a/tests/test_occurrences_client.py
+++ b/tests/test_occurrences_client.py
@@ -1,4 +1,5 @@
 import datetime
+from unittest.mock import Mock
 
 from geopandas import GeoDataFrame
 from pandas import DataFrame
@@ -134,18 +135,12 @@ async def test_occurrences_without_victims(occurrences_client_and_get_mock):
     )
 
 
-@mark.asyncio
-async def test_occurrences_with_format_parameter(
-    occurrences_client_and_get_mock,
-):
-    client, mock = occurrences_client_and_get_mock
-    occurrences = Occurrences(
-        client, id_state=42, type_occurrence="withVictim", format="df"
-    )
-    await occurrences()
-    mock.assert_called_once_with(
+def test_occurrences_with_format_parameter():
+    client_mock = Mock()
+    occurrences = Occurrences(client_mock, id_state=42, format="df")
+    occurrences()
+    occurrences.client.get.assert_called_once_with(
         "http://127.0.0.1/api/v2/occurrences?idState=42&typeOccurrence=withVictim&page=1",
-        headers={"Authorization": "Bearer 42"},
         format="df",
     )
 


### PR DESCRIPTION
Started trying to get the bug (#90 ) by testing it, 

But seems that I still need to understand how to test it.

my line of thinking is:
I need to confirm if, the `format` parameter on `Occurrence` class is passed to `client.get` method, which is an instance of `Client` passed in `Occurrences` instatitation;
So, I believe that I can use `patch.object` to mock `AsyncClient.get` method so I can assert f its been called with the right parameters.
But, as `client.get` should be instantiated, I thin I should mock the config, also.
But the test says that the  "expected call not found".

Am I write? Am I misisng something?