### PR TITLE
update crossfire.__init__ occurrences adding initial_ and final_date

### DIFF
--- a/crossfire/__init__.py
+++ b/crossfire/__init__.py
@@ -25,6 +25,8 @@ def occurrences(
     id_state,
     id_cities=None,
     type_occurrence="all",
+    initial_date=None,
+    final_date=None,
     max_parallel_requests=None,
     format=None,
 ):
@@ -32,6 +34,8 @@ def occurrences(
         id_state,
         id_cities=id_cities,
         type_occurrence=type_occurrence,
+        initial_date=initial_date,
+        final_date=final_date,
         max_parallel_requests=max_parallel_requests,
         format=format,
     )

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -48,6 +48,8 @@ def test_occurrences_with_default_args():
             id_cities=None,
             type_occurrence="all",
             max_parallel_requests=None,
+            initial_date=None,
+            final_date=None,
             format=None,
         )
 
@@ -58,6 +60,8 @@ def test_occurrences_with_custom_args():
             "42",
             id_cities=[1, 2, 3],
             type_occurrence="without",
+            initial_date="2023-01-01",
+            final_date="2023-01-31",
             max_parallel_requests=10,
             format="df",
         )
@@ -65,6 +69,8 @@ def test_occurrences_with_custom_args():
             "42",
             id_cities=[1, 2, 3],
             type_occurrence="without",
+            initial_date="2023-01-01",
+            final_date="2023-01-31",
             max_parallel_requests=10,
             format="df",
         )


### PR DESCRIPTION
@cuducos I believe that the changes done un this commit solve the prolems with `initial` and `final_date` on `occurrences`  available through  `crossfire.__init__`, problem from issue #89 