### PR TITLE
Simplifies occurrences with format test

### DIFF
--- a/tests/test_occurrences_client.py
+++ b/tests/test_occurrences_client.py
@@ -1,5 +1,4 @@
 import datetime
-from unittest.mock import AsyncMock
 
 from geopandas import GeoDataFrame
 from pandas import DataFrame
@@ -13,7 +12,6 @@ from crossfire.clients.occurrences import (
     date_formatter,
 )
 from crossfire.errors import DateFormatError, DateIntervalError
-from crossfire.parser import Metadata
 
 
 def dummy_response(total_pages, last_page):
@@ -137,24 +135,12 @@ async def test_occurrences_without_victims(occurrences_client_and_get_mock):
 
 
 @mark.asyncio
-async def test_occurrences_with_format_parameter():
-    client_mock = AsyncMock()
-    metadata = Metadata(
-        page=1,
-        take=1,
-        item_count=1,
-        page_count=1,
-        has_previous_page=False,
-        has_next_page=False,
-    )
-    client_mock.get.return_value = ("occs", metadata)
-    client_mock.URL = "http://127.0.0.1/api/v2"
+async def test_occurrences_with_format_parameter(
+    occurrences_client_and_get_mock,
+):
+    client_mock, _ = occurrences_client_and_get_mock
     occurrences = Occurrences(client_mock, id_state=42, format="df")
-    await occurrences()
-    occurrences.client.get.assert_called_once_with(
-        "http://127.0.0.1/api/v2/occurrences?idState=42&typeOccurrence=all&page=1",
-        format="df",
-    )
+    assert isinstance(await occurrences(), DataFrame)
 
 
 def test_occurrence_raises_error_for_unknown_occurrence_type():


### PR DESCRIPTION
Instead of using custom mocks, this PR suggests using the existing fixtures to run the test implemented in #91