### PR TITLE
Fix lat lon Occurrences column name

### DIFF
--- a/crossfire/parser.py
+++ b/crossfire/parser.py
@@ -36,13 +36,13 @@ class IncompatibleDataError(CrossfireError):
 
 
 def to_geo_dataframe(df):
-    if not {"latitude_ocorrencia", "longitude_ocorrencia"}.issubset(df.columns):
+    if not {"latitude", "longitude"}.issubset(df.columns):
         raise IncompatibleDataError(
-            "Missing columns `latitude_ocorrencia` and `longitude_ocorrencia`. "
+            "Missing columns `latitude` and `longitude`. "
             "They are needed to create a GeoDataFrame."
         )
 
-    geometry = points_from_xy(df.longitude_ocorrencia, df.latitude_ocorrencia)
+    geometry = points_from_xy(df.longitude, df.latitude)
     return GeoDataFrame(df, geometry=geometry, crs=CRS)
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -12,7 +12,7 @@ from crossfire.parser import (
 )
 
 DATA = [{"answer": 42}]
-GEODATA = [{"answer": 42, "latitude_ocorrencia": 4, "longitude_ocorrencia": 2}]
+GEODATA = [{"answer": 42, "latitude": 4, "longitude": 2}]
 
 
 class DummyError(Exception):


### PR DESCRIPTION
@cuducos either I neglected to review the end point of [Occurrences](https://api.fogocruzado.org.br/docs/endpoint/occurrences) (very likely) or they updated the name of the latitude column (`latitude_ocorrencia` for `latitude` and `longitude_ocorrencia` for `longitude`);
In this PR I update the  expected names of the `latitude` and `longitude` columns.