### PR TITLE
Fix nested columns constant

### DIFF
--- a/crossfire/__init__.py
+++ b/crossfire/__init__.py
@@ -6,7 +6,7 @@ from functools import lru_cache
 from crossfire.clients import AsyncClient, Client  # noqa
 from crossfire.errors import NestedColumnError
 
-NESTED_COLUMNS = {"contextInfo", "transports", "victims", "animalVictims"}
+NESTED_COLUMNS = {"contextInfo"}
 
 
 @lru_cache(maxsize=1)

--- a/crossfire/__init__.py
+++ b/crossfire/__init__.py
@@ -6,7 +6,7 @@ from functools import lru_cache
 from crossfire.clients import AsyncClient, Client  # noqa
 from crossfire.errors import NestedColumnError
 
-NESTED_COLUMNS = {"contextInfo"}
+NESTED_COLUMNS = {"contextInfo", "state", "region", "city", "neighborhood", "locality"}
 
 
 @lru_cache(maxsize=1)

--- a/crossfire/__init__.py
+++ b/crossfire/__init__.py
@@ -6,7 +6,14 @@ from functools import lru_cache
 from crossfire.clients import AsyncClient, Client  # noqa
 from crossfire.errors import NestedColumnError
 
-NESTED_COLUMNS = {"contextInfo", "state", "region", "city", "neighborhood", "locality"}
+NESTED_COLUMNS = {
+    "contextInfo",
+    "state",
+    "region",
+    "city",
+    "neighborhood",
+    "locality",
+}
 
 
 @lru_cache(maxsize=1)

--- a/tests/test_flatten.py
+++ b/tests/test_flatten.py
@@ -22,7 +22,7 @@ def teste_flatten_with_emptylist():
 # test the flatten function with a dictionary mocking it to assert _flatten_dict function is being called
 def test_flatten_dict():
     flattened_dict = flatten(
-        DICT_DATA, nested_columns=["contextInfo", "transports"]
+        DICT_DATA, nested_columns=["contextInfo", "neighborhood"]
     )
     assert flattened_dict == [
         {


### PR DESCRIPTION
@cuducos , during the construction of the `flatten` function I have wrongly added some "column name" (dict keys, for now) in the `NESTED_COLUMNS` constant.

I did it by reading the API documentation. But once finished the PR #100 I did some test with real data an realized that some "columns" are not nested. I created a issue #101 about it. (sorry, I should have tested before closing the PR... I will try to be more careful next time)

Today I fixed it removing those "columns names" and added some other. This time I have tested with occurrences from the second semester of 2022.

```python
from crossfire import AsyncClient, flatten

client = AsyncClient()
states_dict, _ = await client.states(format="dict")
states_df, _ = await client.states(format="df")

cities_rj, _ = await client.cities(state_id=states_df.id.iloc[0], format="df")

occs = await client.occurrences(
    id_state=cities_rj.state.iloc[16].get("id"),
    id_cities=cities_rj.id.iloc[16],
    initial_date="2022-06-01",
    final_date="2023-01-01",
    # format="df",
)

flatten(occs)
```
Everythning seems to be right.