### PR TITLE
Fixes asyncio loop issue on Colab (and other situations where a loop is already running)

### DIFF
--- a/crossfire/clients/__init__.py
+++ b/crossfire/clients/__init__.py
@@ -4,6 +4,7 @@ from urllib.parse import urlencode
 
 import httpx
 from decouple import UndefinedValueError, config
+from nest_asyncio import apply
 
 from crossfire.clients.occurrences import Occurrences
 from crossfire.errors import CrossfireError, RetryAfterError
@@ -135,6 +136,7 @@ class Client(AsyncClient):
             password=password,
             max_parallel_requests=max_parallel_requests,
         )
+        apply()
 
     def states(self, format=None):
         loop = get_event_loop()

--- a/poetry.lock
+++ b/poetry.lock
@@ -288,6 +288,17 @@ files = [
 ]
 
 [[package]]
+name = "nest-asyncio"
+version = "1.6.0"
+description = "Patch asyncio to allow nested event loops"
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c"},
+    {file = "nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe"},
+]
+
+[[package]]
 name = "numpy"
 version = "1.26.2"
 description = "Fundamental package for array computing in Python"
@@ -740,4 +751,4 @@ geodf = ["geopandas", "pandas"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9,<3.13"
-content-hash = "301034fe004ae9c09441bc0b0cba81bc9b00cfda664c546aac99f2bbaa96d561"
+content-hash = "a0c4b1ee447806def0b8d510be05391ebb6ccb253d0ea294fc4a32356e936e92"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ exclude =  ["env-example"]
 python = "^3.9,<3.13"
 geopandas = { version = "^0.13.2", optional = true }
 httpx = "^0.25.0"
+nest-asyncio = "^1.6.0"
 pandas = { version = "^2.1.1", optional = true }
 python-decouple = "^3.5"
 tqdm = "^4.66.1"


### PR DESCRIPTION
Fixes `asyncio` error when running in environments with another loop running (e.g. Colab).

Long story short, the added library explains the underlying problem:

> By design asyncio [does not allow](https://github.com/python/cpython/issues/66435) its event loop to be nested […]
>
> This module patches asyncio to allow nested use of asyncio.run and loop.run_until_complete.